### PR TITLE
Update capfile after transition to Github

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -143,7 +143,7 @@ class Ability
     # Because otherwise you also cannot read the proposals due to the url structure.
     can :read, Admin::Proposals::Call
 
-    can %I[read answer], Admin::Questionnaires::Questionnaire, users: { id: user.id }
+    can %I[read answer set_answers], Admin::Questionnaires::Questionnaire, users: { id: user.id }
 
     can :read, Admin::Feedback, show: { users: { id: user.id } }
 

--- a/app/models/admin/questionnaires/questionnaire_template.rb
+++ b/app/models/admin/questionnaires/questionnaire_template.rb
@@ -13,9 +13,19 @@
 # == Schema Information End
 #++
 class Admin::Questionnaires::QuestionnaireTemplate < ApplicationRecord
+  include ApplicationHelper
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   has_many :questions, as: :questionable
 
   accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
+
+  def as_json(options = {})
+    defaults = { include: [:questions] }
+
+    options = merge_hash(defaults, options)
+
+    super(options)
+  end
 end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,4 @@
 <% @hide_alert = true %>
-<% @hide_cookie_notice = true %>
 
 <% content_for :head do %>
   <%= stylesheet_link_tag "login", :media => "all" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,8 +1,7 @@
 <% @hide_alert = true %>
-<% @hide_cookie_notice = true %>
 
 <% content_for :head do %>
-  <%= stylesheet_link_tag "login", :media => "all" %>
+  <%= stylesheet_link_tag "login", media: "all" %>
 <% end %>
 
 <div class="container">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,3 @@
-<% @hide_cookie_notice = true %>
-
 <div class="container">
   <div class="span12">
     <!--<h2>Sign up</h2>-->

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,3 @@
-<% @hide_cookie_notice = true %>
-
 <% content_for :head do %>
   <%= stylesheet_link_tag "login", :media => "all" %>
 <% end %>

--- a/app/views/registrations/reactivation.html.erb
+++ b/app/views/registrations/reactivation.html.erb
@@ -1,5 +1,3 @@
-<% @hide_cookie_notice = true %>
-
 <div class="container">
   <div class="row">
     <div class="span12">
@@ -19,7 +17,7 @@
     </div>
 
     <div class="span6">
-      <h2>Reactive Membership</h2>
+      <h2>Reactivate Membership</h2>
 
       <p>
         If you have renewed your membership at Box Office, please enter your

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,6 @@
 set :application, 'BlackLightning'
-set :repo_url,    'git@bitbucket.org:bedlamtheatre/black_lightning.git'
+set :repo_url,    'git@github.com:EdinburghUniversityTheatreCompany/black_lightning.git'
+set :branch,      'main'
 
 set :rails_env, 'production' # added for delayed job
 


### PR DESCRIPTION
Just some small things as described above. This is the first time in ages we used questionnaires, so something was bound to go wrong.
  
## Changes
- Update deploy.rb to refer to the new github repo.
  
## Fixes
- Fix permissions issue where the user was authorised for the /answer page for proposals, but not for the PUT to /set_answers. 
- Fix issue where Questionnaire templates could not be loaded due to the questions not being merged into the json.
 