### PR TITLE
Fixes for the previous Pull Request

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module ChaosRails
     # the framework and any gems in your application.
 
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.1
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.eager_load_paths << "#{config.root}/lib"

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module ChaosRails
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.eager_load_paths << "#{config.root}/lib"
+    Rails.autoloaders.main.ignore(config.root.join('lib/generators'))
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
Zeitwerk did not ignore the generators like it should

Rails defaults to 6.1