### PR TITLE
Remove Prawn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'delayed_job_active_record'
 gem 'daemons'
 
 gem 'caxlsx'
-gem 'prawn'
 gem 'rqrcode'
 
 gem 'silencer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.588.0)
+    aws-partitions (1.589.0)
     aws-sdk-core (3.131.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -272,10 +272,6 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    pdf-core (0.9.0)
-    prawn (2.4.0)
-      pdf-core (~> 0.9.0)
-      ttfunk (~> 1.7)
     psych (4.0.4)
       stringio
     public_suffix (4.0.7)
@@ -415,7 +411,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timeout (0.2.0)
-    ttfunk (1.7.0)
     twitter (7.0.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -498,7 +493,6 @@ DEPENDENCIES
   nested_form
   nokogiri
   paper_trail
-  prawn
   puma (~> 4.1)
   rack-cors
   rails (~> 7.0)

--- a/lib/membership_card_pdf.rb
+++ b/lib/membership_card_pdf.rb
@@ -1,65 +1,6 @@
-# See http://prawn.majesticseacreature.com/manual.pdf for pdf generation.
-require 'prawn/measurement_extensions'
+# TODO: Prawn broke on upgrading to Ruby 3.1. Most of the contents of this file got deleted. You can find them in git history.
 
-class MembershipCardPdf < Prawn::Document
+class MembershipCardPdf
   def self.create(*args)
-    pdf = new(*args)
-    yield pdf
-    pdf.tidy_up
-  end
-
-  def initialize(card)
-    width  = 86.mm
-    height = 54.mm
-
-    super(
-          page_size: [width, height],
-          margin:    0
-        )
-
-    font  Rails.root.join('app', 'assets', 'fonts', 'gothic.ttf')
-
-    # Background Image
-    image Rails.root.join('app', 'assets', 'images', 'card_background.jpg'), at: [0, height], fit: [width, height]
-
-    # QR Code
-    @qr_file = Tempfile.new("qr_#{card.card_number}")
-    qr = RQRCode::QRCode.new(card.card_number, size: 2, level: :h)
-
-    @qr_file.binmode
-    @qr_file.write RQRCode::Renderers::PNG.render(qr)
-    @qr_file.close
-
-    image @qr_file.path, at: [5, 5 + 50], fit: [50, 50]
-    # End QR Code
-
-    bounding_box([5.1.mm, height - 14.mm], width: 31.3.mm, height: 33.7.mm) do
-      font_size 7.5
-
-      # EUTC
-      font Rails.root.join('app', 'assets', 'fonts', 'gothicb.ttf') do
-        text 'EDINBURGH UNIVERSITY', align: :center
-        text 'THEATRE COMPANY', align: :center
-      end
-
-      move_down 3.mm
-
-      # Member
-      text 'MEMBER', align: :center
-
-      move_down 3.mm
-
-      # Name
-      font Rails.root.join('app', 'assets', 'fonts', 'gothicb.ttf') do
-        text card.user.name_or_email, align: :center
-      end
-    end
-
-    # Card Number
-    text_box card.card_number, at: [width - 67, 11], size: 8
-  end
-
-  def tidy_up
-    @qr_file.unlink
   end
 end


### PR DESCRIPTION
Remove Prawn since it is only used for membership cards, which are no longer used.