### PR TITLE
Bootstrap 5 - Extra Fixes

### DIFF
--- a/app/mailers/contact_form_mailer.rb
+++ b/app/mailers/contact_form_mailer.rb
@@ -4,6 +4,6 @@ class ContactFormMailer < ApplicationMailer
     @name = name
     @recipient_email = recipient_email
   
-    mail(to: [sender_email, recipient_email], subject: subject, from: 'contactform@bedlamtheatre.co.uk', reply_to: sender_email)
+    mail(to: [sender_email, recipient_email], subject: subject, reply_to: sender_email)
   end
 end

--- a/app/models/admin/proposals/proposal.rb
+++ b/app/models/admin/proposals/proposal.rb
@@ -68,29 +68,31 @@ class Admin::Proposals::Proposal < ApplicationRecord
 
     labels << case successful
               when true
-                generate_label(:success, 'Successful', pull_right)
+                generate_label(:success, 'Successful')
               when false
-                generate_label(:danger, 'Unsuccessful', pull_right)
+                generate_label(:danger, 'Unsuccessful')
               else
                 case approved
                 when true
-                  generate_label(:success, 'Approved', pull_right)
+                  generate_label(:success, 'Approved')
                 when false
-                  generate_label(:danger, 'Rejected', pull_right)
+                  generate_label(:danger, 'Rejected')
                 else
-                  generate_label(:warning, 'Waiting for Approval', pull_right)
+                  generate_label(:warning, 'Waiting for Approval')
                 end
               end
 
-    labels << generate_label(:danger, 'Late', pull_right) if late
-    labels << generate_label(:danger, 'Has Debtors', pull_right) if has_debtors
+    labels << generate_label(:danger, 'Late') if late
+    labels << generate_label(:danger, 'Has Debtors') if has_debtors
 
+    labels_html = labels.join("\n").html_safe
+
+    # Wrap the whole list of labels in a float right so that the margins stay preserved.
     if pull_right
-      # Bcause the highest float-right will be farthest to the right, the order has to be reversed.
-      return "#{labels.reverse.join("\n")}".html_safe
-    else
-      return labels.join("\n").html_safe
+      return "<div class=\"float-right\">#{labels_html}</div>".html_safe
     end
+
+    return labels_html
   end
 
   ##

--- a/app/views/admin/dashboard/_committee_staffing_widget.html.erb
+++ b/app/views/admin/dashboard/_committee_staffing_widget.html.erb
@@ -1,14 +1,15 @@
 Displays the amount of committee rep slots staffed per semester for each committee member.
-<br>
-<dl>
-  <% committee = Role.where(name: "Committee").first.users%>
-  <% committee.each do |person|%>
-    
-      <dt><%= person.name  %></dt>
-      <dd>
-        <%= person.staffing_jobs.where(name:"Committee Rep").all.select{|j| j.staffable.start_time.between?(start_of_year,christmas)}.count %>
-        /
-        <%= person.staffing_jobs.where(name:"Committee Rep").all.select{|j| j.staffable.start_time.between?(christmas,next_year_start)}.count %>
-      </dd>
-  <% end %>
-</dl>
+<% committee = Role.where(name: "Committee").first.users %>
+
+
+<% committee.each do |person|%>
+  <div class="row">
+    <div class="col-auto"><b><%= person.name %></b></div>
+
+    <div class="col-auto">
+    <%= person.staffing_jobs.where(name:"Committee Rep").all.select{|j| j.staffable.start_time.between?(start_of_year,christmas)}.count %>
+    /
+    <%= person.staffing_jobs.where(name:"Committee Rep").all.select{|j| j.staffable.start_time.between?(christmas,next_year_start)}.count %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/dashboard/_shows_widget.html.erb
+++ b/app/views/admin/dashboard/_shows_widget.html.erb
@@ -1,4 +1,4 @@
-<% future_shows = Show.future.first(5) %>
+<% future_shows = Show.future.reorder('start_date ASC').first(5) %>
 <% future_shows.each do |show| %>
   <p><%= link_to show.name, admin_show_path(show) %></p>
 <% end %>

--- a/app/views/admin/dashboard/_staffings_widget.html.erb
+++ b/app/views/admin/dashboard/_staffings_widget.html.erb
@@ -1,18 +1,16 @@
-<div style="height: 210px; overflow: hidden;">
-  <% upcoming_staffing = Admin::Staffing.accessible_by(current_ability).future.order('start_time ASC').first(5) %>
-  
-  <% upcoming_staffing.each do |staffing| %>
-    <p>
-      <%= link_to (l staffing.start_time, format: :short) + ": " + staffing.show_title, admin_staffing_path(staffing) %>
+<% upcoming_staffing = Admin::Staffing.accessible_by(current_ability).future.order('start_time ASC').first(5) %>
 
-      <% remaining_positions = staffing.staffing_jobs.count - staffing.filled_jobs %>
-      <% if remaining_positions > 0 %>
-        <%= generate_label('danger', remaining_positions.to_s, rounded=true) %>
-      <% end %>
-    </p>
-  <% end %>
+<% upcoming_staffing.each do |staffing| %>
+  <p>
+    <%= link_to (l staffing.start_time, format: :short) + ": " + staffing.show_title, admin_staffing_path(staffing) %>
 
-  <% if upcoming_staffing.empty? then %>
-    <p>There are no upcoming staffing slots.</p>
-  <% end %>
-</div>
+    <% remaining_positions = staffing.staffing_jobs.count - staffing.filled_jobs %>
+    <% if remaining_positions > 0 %>
+      <%= generate_label('danger', remaining_positions.to_s, rounded=true) %>
+    <% end %>
+  </p>
+<% end %>
+
+<% if upcoming_staffing.empty? then %>
+  <p>There are no upcoming staffing slots.</p>
+<% end %>

--- a/app/views/admin/maintenance_debts/index.html.erb
+++ b/app/views/admin/maintenance_debts/index.html.erb
@@ -24,13 +24,13 @@
 end %>
 
 <% if @is_specific_user
-  search_fields = {
-      user_full_name_cont:  { slug: 'defaults.user' },
-      show_name_cont:       { slug: 'defaults.show_name' },
-      show_fulfilled:       { slug: 'defaults.show_fulfilled', type: :boolean }
-  } 
-else 
   search_fields = nil
+else 
+  search_fields = {
+    user_full_name_cont:  { slug: 'defaults.user' },
+    show_name_cont:       { slug: 'defaults.show_name' },
+    show_fulfilled:       { slug: 'defaults.show_fulfilled', type: :boolean }
+} 
 end %>
 
 <%= render 'shared/pages/index', resource_class: Admin::MaintenanceDebt, resources: @maintenance_debts, headers: headers, field_sets: field_sets, search_fields: search_fields,

--- a/app/views/admin/proposals/proposals/show.html.erb
+++ b/app/views/admin/proposals/proposals/show.html.erb
@@ -20,7 +20,6 @@
 
 <% content_for :extra_show_actions do %>
   <%= get_link @proposal, :convert, http_method: :put, additional_condition: @proposal.successful %>
-  <%= get_link Admin::Proposals::Proposal, :index, link_text: 'View Other Proposals', link_target: admin_proposals_call_proposals_path(@proposal.call), http_method: 'get' %>
 
   <% if can?(:approve, @proposal) && @proposal.approved.nil? %>
       <% if @proposal.has_debtors %>
@@ -34,4 +33,5 @@
   <% end %>
 <% end %>
 
-<%= render('shared/pages/show', object: @proposal, fields: fields) %>
+<% show_actions_args = { index_link_params: { link_text: 'View Other Proposals', link_target: admin_proposals_call_proposals_path(@proposal.call)} } %>
+<%= render('shared/pages/show', object: @proposal, fields: fields, show_actions_args: show_actions_args ) %>

--- a/test/functional/admin/dashboard_controller_test.rb
+++ b/test/functional/admin/dashboard_controller_test.rb
@@ -82,21 +82,9 @@ class Admin::DashboardControllerTest < ActionController::TestCase
     assert_match extra_committee.first_name, response.body
   end
 
-  test 'delayed_jobs widget' do
-    assert_widget_does_not_error 'delayed_jobs'
-    assert_match 'Enqueued Jobs', response.body
-    assert_match 'Working Jobs', response.body
-    assert_match 'Pending Jobs', response.body
-    assert_match 'Failed Jobs', response.body
-  end
-
   test 'opportunities widget' do
     FactoryBot.create_list(:opportunity, 7)
     assert_widget_does_not_error 'opportunities'
-  end
-
-  test 'reports widget' do
-    assert_widget_does_not_error 'reports'
   end
 
   test 'non-existent widget' do

--- a/test/functional/admin/resources_controller_test.rb
+++ b/test/functional/admin/resources_controller_test.rb
@@ -20,8 +20,6 @@ class Admin::ResourcesControllerTest < ActionController::TestCase
     assert_response :success
 
     assert_equal 'Tech', assigns(:editable_block).name
-
-    assert_equal get_subpages('admin/resources/tech'), assigns(:subpages)
   end
 
   test 'should get membership checker' do

--- a/test/functional/admin/shows_controller_test.rb
+++ b/test/functional/admin/shows_controller_test.rb
@@ -198,7 +198,7 @@ class Admin::ShowsControllerTest < ActionController::TestCase
     @show = FactoryBot.create(:show, staffing_debt_start: Date.current)
 
     assert_difference 'Admin::StaffingDebt.count', @show.team_members.count * 2 do
-      post :create_staffing_debts, params: { id: @show.slug, number_of_slots: 2 }
+      post :create_staffing_debts, params: { id: @show.slug, create_show_staffing_debts: { number_of_slots: 2 } }
     end
 
     assert_redirected_to admin_show_path(@show)
@@ -215,7 +215,7 @@ class Admin::ShowsControllerTest < ActionController::TestCase
     assert_redirected_to admin_show_path(@show)
     assert_includes flash[:notice], 'specify the amount'
 
-    post :create_staffing_debts, params: { id: @show.slug, number_of_slots: 2 }
+    post :create_staffing_debts, params: { id: @show.slug, create_show_staffing_debts: { number_of_slots: 2 } }
 
     assert_redirected_to admin_show_path(@show)
     assert_includes flash[:notice], 'Could not create Staffing obligations because the start date has not been set yet.'

--- a/test/models/admin/proposals/proposal_test.rb
+++ b/test/models/admin/proposals/proposal_test.rb
@@ -112,7 +112,7 @@ class Admin::Proposals::ProposalTest < ActiveSupport::TestCase
     @proposal.late = true
     @proposal.approved = false
 
-    expected_labels = "<span class=\"badge bg-danger float-right\">Late</span>\n<span class=\"badge bg-danger float-right\">Rejected</span>"
+    expected_labels = "<div class=\"float-right\"><span class=\"badge bg-danger\">Rejected</span>\n<span class=\"badge bg-danger\">Late</span></div>"
 
     assert_equal expected_labels, @proposal.labels(true)
   end
@@ -140,7 +140,7 @@ class Admin::Proposals::ProposalTest < ActiveSupport::TestCase
   test 'labels for unsuccessful proposal with pull right' do
     @proposal.successful = false
 
-    expected_labels = "<span class=\"badge bg-danger float-right\">Unsuccessful</span>"
+    expected_labels = "<div class=\"float-right\"><span class=\"badge bg-danger\">Unsuccessful</span></div>"
 
     assert_equal expected_labels, @proposal.labels(true)
   end


### PR DESCRIPTION
Fixed some tests
- Update Committee Staffing widget to display the name + stats on one line
- Add Search Form back to Maintenance Debts
- Send contact form emails from the default from email
- Fix the proposal index link on the proposals show page
- Fix margins in proposal labels
- Upcoming shows widget now shows the soonest show at the top