### PR TITLE
Fixes on index pages

### DIFF
--- a/app/controllers/generic_controller.rb
+++ b/app/controllers/generic_controller.rb
@@ -16,6 +16,8 @@ module GenericController
 
     response.headers['X-Total-Count'] = resources.count.to_s
 
+    @editable_block_name = index_editable_block_name
+
     respond_to do |format|
       format.html { render index_filename }
       format.json { render json: resources }
@@ -271,6 +273,10 @@ module GenericController
 
   def index_filename
     'index'
+  end
+
+  def index_editable_block_name
+    "Index - #{@current_path.titleize} Description"
   end
 
   ##

--- a/app/helpers/editable_block_helper.rb
+++ b/app/helpers/editable_block_helper.rb
@@ -1,4 +1,6 @@
 module EditableBlockHelper
+  include LinkHelper
+
   def display_block(name, admin_page, display_edit = true)
     @editable_block = Admin::EditableBlock.find_by_name(name)
 

--- a/app/helpers/editable_block_helper.rb
+++ b/app/helpers/editable_block_helper.rb
@@ -4,7 +4,7 @@ module EditableBlockHelper
 
     if @editable_block.nil?
       if current_ability.can?(:create, Admin::EditableBlock)
-        return ('Block not defined. ' + link_to('Create Block', new_admin_editable_block_path(name: name))).html_safe
+        return ('Block not defined. ' + link_to_create_block(name)).html_safe
       else
         return 'Block not defined'
       end
@@ -18,8 +18,12 @@ module EditableBlockHelper
     # Will only actually display edit if the user also has permission to edit the block.
     return render partial: '/editable_blocks/display', locals: { display_edit: display_edit }
   end
+  
+  def link_to_create_block(name)
+    get_link(Admin::EditableBlock, :new, link_text: generate_icon_prefix('align-left', 'Create Editable Block'), link_target: new_admin_editable_block_path(name: name))
+  end
 
-  def block_exists(name)
+  def block_exists?(name)
     return Admin::EditableBlock.find_by_name(name).present?
   end
 end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -68,15 +68,16 @@ module LinkHelper
 
     condition = current_ability.can?(action, object) && additional_condition if condition.nil?
 
+    link_text = generate_link_text(link_text, object, action, prefix, append_name)
+
+    # If the condition is not true, return either the link_text or nothing.
     unless condition
       if return_link_text_if_no_permission || (return_link_text_if_no_permission.nil? && action == :show)
-        return generate_link_text(link_text, object, action, prefix, append_name)
+        return link_text
       else
-        return unless condition
+        return nil
       end
     end
-
-    link_text = generate_link_text(link_text, object, action, prefix, append_name)
 
     # You might notice that the names of the variables given do not match the parameter names defined in the function definition.
     # We switched from data confirmation plugins, and they have a different naming convention.

--- a/app/helpers/search_form_helper.rb
+++ b/app/helpers/search_form_helper.rb
@@ -4,7 +4,7 @@ module SearchFormHelper
   NUMBER_OUTSIDE_COLLAPSE = 3
   NUMBER_BEFORE_COLLAPSE = 5
 
-  def split_search_form_input_fields(input_fields)
+  def split_search_form_input_fields(input_fields, columns)
     # Do not include fields that have no params
     input_fields = input_fields.reject { |key, params| params.nil? }
 
@@ -12,11 +12,11 @@ module SearchFormHelper
     button_params, input_fields = input_fields.partition { |key, params| params[:type] == :submit_button }
 
     # Are there more fields than the threshold before collapsing.
-    should_collapse = input_fields.length > NUMBER_BEFORE_COLLAPSE
+    should_collapse = input_fields.length > NUMBER_BEFORE_COLLAPSE * columns
 
     if should_collapse
-      input_fields_outside_collapse = Hash[input_fields.to_a[0, NUMBER_OUTSIDE_COLLAPSE]]#input_fields.to(NUMBER_OUTSIDE_COLLAPSE - 1)
-      input_fields_in_collapse = Hash[input_fields.to_a[NUMBER_OUTSIDE_COLLAPSE, input_fields.length]]
+      input_fields_outside_collapse = Hash[input_fields.to_a[0, NUMBER_OUTSIDE_COLLAPSE * columns]]
+      input_fields_in_collapse = Hash[input_fields.to_a[NUMBER_OUTSIDE_COLLAPSE * columns, input_fields.length]]
     else
       input_fields_outside_collapse = input_fields
       input_fields_in_collapse = nil
@@ -25,59 +25,67 @@ module SearchFormHelper
     return input_fields_in_collapse, input_fields_outside_collapse, button_params
   end
 
-  def render_search_form_fields(f, input_fields)
+  def render_search_form_fields(f, input_fields, columns)
     output = ''
 
-    input_fields.each do |key, params|
-      if params.key?(:label)
-          label = params[:label]
-      elsif params.key?(:slug)
-          label = t("simple_form.labels.#{params[:slug]}")
-      else
-          label = key.to_s.humanize
-      end
+    raise(ArgumentError, 'The amount of column should be a divisor of 12') unless [1, 2, 3, 4, 6, 12].include?(columns)
 
-      # Reassign label back to params in case it gets passed through to an input.
-      params[:label] = label
+    output += "<div class=\"row row-cols-#{columns}\">"
 
-      # Render specific input fields for some types.
-      if params.key?(:type) && params[:type] != :text
-          if params[:type] == :boolean
-              # If it is a boolean, just render the boolean field and continue the loop.
-              output += render('shared/boolean_search_form_field', f: f, name: key, label: label)
-              next
-          elsif params[:type] == :select
-              # By default, you need to select an item, while usually, you want to have the filtering using a select be optional.
-              params[:include_blank] = true if params[:include_blank].nil?
-
-              # No `next`. Just go on to render a normal select input, but with the above parameter set.
-          elsif params[:type] == :date_range
-              # Render a date range with options specified.
-              output += render('shared/date_range_search_form_field', { f: f }.merge(params[:options]))
-              next
-          elsif params[:type] == :submit_button
-            raise(ArgumentError, 'A submit button has not been filtered out in the search fields.')
-          end
-      end
-
-      # If there is no type key, text is implied, and we just render an input.
-
-      # Set email fields to render as text fields to prevent email and url validations, unless there is already an as in the params
-      if !params.key?(:as) && (key.to_s.include?('email') || key.to_s.include?('url'))
-          params[:as] = 'string'
-      end
-
-      # By default, the fields are required, so override that and set them to not required unless explicitly stated.
-      # These are search fields so making them required is odd.
-      params[:required] = false if params[:required].nil?
-
-      # Remove the type and slug from the parameters since they are not relevant for the input.
-      params = params.except!([:type, :slug])
-
-      # Render the input itself, unless it was caught by the switch earlier and is already rendered.
-      output += f.input(key, params)
+    input_fields.each_with_index do |(key, params), i|
+      output += render_search_form_field(f, key, params)
     end
+    output += '</div>'
 
     return output.html_safe
+  end
+
+  def render_search_form_field(f, key, params)
+    if params.key?(:label)
+        label = params[:label]
+    elsif params.key?(:slug)
+        label = t("simple_form.labels.#{params[:slug]}")
+    else
+        label = key.to_s.humanize
+    end
+
+    # Reassign label back to params in case it gets passed through to an input.
+    params[:label] = label
+
+    # Render specific input fields for some types.
+    if params.key?(:type) && params[:type] != :text
+        if params[:type] == :boolean
+            # If it is a boolean, just render the boolean field and continue the loop.
+            return render('shared/boolean_search_form_field', f: f, name: key, label: label)
+        elsif params[:type] == :select
+            # By default, you need to select an item, while usually, you want to have the filtering using a select be optional.
+            params[:include_blank] = true if params[:include_blank].nil?
+
+            # No `next`. Just go on to render a normal select input, but with the above parameter set.
+        elsif params[:type] == :date_range
+            # Render a date range with options specified.
+            return render('shared/date_range_search_form_field', { f: f }.merge(params[:options]))
+        elsif params[:type] == :submit_button
+          raise(ArgumentError, 'A submit button has not been filtered out in the search fields.')
+        end
+    end
+
+    # If there is no type key, text is implied, and we just render an input.
+
+    # Set email fields to render as text fields to prevent email and url validations, unless there is already an as in the params
+    if !params.key?(:as) && (key.to_s.include?('email') || key.to_s.include?('url'))
+        params[:as] = 'string'
+    end
+
+    # By default, the fields are required, so override that and set them to not required unless explicitly stated.
+    # These are search fields so making them required is odd.
+    params[:required] = false if params[:required].nil?
+
+    # Remove the type and slug from the parameters since they are not relevant for the input.
+    params = params.except!([:type, :slug])
+
+    # Render the input itself, unless it was caught by the switch earlier and is already rendered.
+    # Wrap the input in a col so we cal columnise the form.
+    return "  <div class=\"col\">\n  #{f.input(key, params)}\n  </div>\n"
   end
 end

--- a/app/helpers/search_form_helper.rb
+++ b/app/helpers/search_form_helper.rb
@@ -19,7 +19,7 @@ module SearchFormHelper
       input_fields_in_collapse = Hash[input_fields.to_a[NUMBER_OUTSIDE_COLLAPSE * columns, input_fields.length]]
     else
       input_fields_outside_collapse = input_fields
-      input_fields_in_collapse = nil
+      input_fields_in_collapse = []
     end
 
     return input_fields_in_collapse, input_fields_outside_collapse, button_params

--- a/app/views/admin/marketing_creatives/categories/index.html.erb
+++ b/app/views/admin/marketing_creatives/categories/index.html.erb
@@ -1,6 +1,6 @@
 <% content = render('admin/marketing_creatives/categories/gallery', categories: @categories) %>
 
-<% quick_actions = get_link(MarketingCreatives::Profile, :sign_up, http_method: :get) %>
+<% quick_actions = [get_link(MarketingCreatives::Profile, :sign_up, http_method: :get)] %>
 
 <% search_fields = {
     name_cont: { slug: 'defaults.name' }

--- a/app/views/admin/proposals/call_question_templates/index.html.erb
+++ b/app/views/admin/proposals/call_question_templates/index.html.erb
@@ -1,4 +1,4 @@
-<% quick_actions = get_link Admin::Proposals::Call, :index, link_text: 'Back to Proposal Calls' %>
+<% quick_actions = [get_link(Admin::Proposals::Call, :index, link_text: 'Back to Proposal Calls')] %>
 
 <% headers = [:name] %>
 

--- a/app/views/admin/proposals/proposals/index.html.erb
+++ b/app/views/admin/proposals/proposals/index.html.erb
@@ -1,8 +1,6 @@
-<% quick_actions = get_link(Admin::Proposals::Proposal, :new, additional_condition: @call.open?, query_params: { call_id: @call.id }).presence || '' %>
-<% quick_actions += get_link(@call, :edit, append_name: true) %>
-<% quick_actions += get_link(Admin::Proposals::Call, :index, link_text: 'Back To Calls') %>
-
-<% quick_actions = quick_actions.html_safe %>
+<% quick_actions = [get_link(Admin::Proposals::Proposal, :new, additional_condition: @call.open?, query_params: { call_id: @call.id })] %>
+<% quick_actions << get_link(@call, :edit, append_name: true) %>
+<% quick_actions << get_link(Admin::Proposals::Call, :index, link_text: 'Back To Calls') %>
 
 <% content = render('admin/proposals/proposals/index_content') %>
 

--- a/app/views/admin/questionnaires/questionnaire_templates/index.html.erb
+++ b/app/views/admin/questionnaires/questionnaire_templates/index.html.erb
@@ -1,4 +1,4 @@
-<% quick_actions = get_link Admin::Questionnaires::Questionnaire, :index, link_text: 'Back to Questionnaires'%>
+<% quick_actions = [get_link(Admin::Questionnaires::Questionnaire, :index, link_text: 'Back to Questionnaires')] %>
 
 <% headers = [:name] %>
 

--- a/app/views/admin/questionnaires/questionnaires/_index_content.erb
+++ b/app/views/admin/questionnaires/questionnaires/_index_content.erb
@@ -3,6 +3,8 @@
 
 <% if @show_current_term_only %>
   <p>By default, this display only includes questionnaires for events taking place during the current semester. Please use the search form if you want to view older questionnaires.</p>
+<% elsif @questionnaires.empty? %>
+  <p>There are no questionnaires matching this search. Have you expanded the date range?</p>
 <% end %>
 
 <% @questionnaires.each do |event_name, questionnaires| %>

--- a/app/views/admin/questionnaires/questionnaires/index.html.erb
+++ b/app/views/admin/questionnaires/questionnaires/index.html.erb
@@ -1,4 +1,4 @@
-<% quick_actions = get_link(Admin::Questionnaires::QuestionnaireTemplate, :index) %>
+<% quick_actions = [get_link(Admin::Questionnaires::QuestionnaireTemplate, :index)] %>
 
 <% content = render('admin/questionnaires/questionnaires/index_content') %>
 

--- a/app/views/admin/roles/show.html.erb
+++ b/app/views/admin/roles/show.html.erb
@@ -26,7 +26,7 @@
 
 <% content_for :users do %>
   <% search_fields = { full_name_cont:   { slug: 'defaults.name' } } %>
-  <%= render('shared/search_form', input_fields: search_fields, url: admin_role_url(@role)) %>
+  <%= render('shared/search_form', input_fields: search_fields, url: admin_role_url(@role), columns: 1) %>
 
   <% headers = [:name] %>
   <% field_sets = @users.map { |user| { fields: [user] } } %>

--- a/app/views/admin/staffing_templates/index.html.erb
+++ b/app/views/admin/staffing_templates/index.html.erb
@@ -1,4 +1,4 @@
-<% quick_actions = get_link Admin::Staffing, :index, link_text: 'Back to Staffings' %>
+<% quick_actions = [get_link(Admin::Staffing, :index, link_text: 'Back to Staffings')] %>
 
 <% headers = [:name] %>
 

--- a/app/views/admin/techies/index.html.erb
+++ b/app/views/admin/techies/index.html.erb
@@ -1,6 +1,4 @@
-<% quick_actions = link_to tree_admin_techies_url, class: 'btn btn-secondary' do %>
-  <i class="fas fa-tree-alt" aria-hidden=”true”></i> Tree
-<% end %>
+<% quick_actions = [link_to(generate_icon_prefix('tree', 'Tree'), tree_admin_techies_url, class: 'btn btn-secondary')] %>
 
 <% headers = [:name] %>
 

--- a/app/views/admin/venues/index.html.erb
+++ b/app/views/admin/venues/index.html.erb
@@ -13,6 +13,6 @@
     address_cont:     { slug: 'defaults.address'}
 } %>
 
-<% quick_actions = get_link(Venue, :map, http_method: :get) %>
+<% quick_actions = [get_link(Venue, :map, http_method: :get, link_text: generate_icon_prefix('map', 'Map'))] %>
 
 <%= render 'shared/pages/index', resource_class: Venue, resources: @venues, headers: headers, field_sets: field_sets, search_fields: search_fields, quick_actions: quick_actions %>

--- a/app/views/archives/proposals/index.html.erb
+++ b/app/views/archives/proposals/index.html.erb
@@ -15,7 +15,7 @@ search_form = render('/shared/pages/public/partials/search_form', search_fields:
 %>
 
 <% content_for :proposal_archive_content do %>
-  <% if @proposals.present? %>
+  <% if @proposals.any? %>
     <% @proposals.each do |call, proposals| %>
       <% div_name = "call_" + call.id.to_s + "_proposals" %>
       <% title_right = "<span class=\"float-right mt-2 mr-1\">Submission Deadline: #{l call.submission_deadline, format: :short } | Editing Deadline: #{l call.editing_deadline, format: :short }</span>".html_safe %>

--- a/app/views/archives/proposals/index.html.erb
+++ b/app/views/archives/proposals/index.html.erb
@@ -15,18 +15,22 @@ search_form = render('/shared/pages/public/partials/search_form', search_fields:
 %>
 
 <% content_for :proposal_archive_content do %>
-  <% @proposals.each do |call, proposals| %>
-    <% div_name = "call_" + call.id.to_s + "_proposals" %>
-    <% title_right = "<span class=\"float-right mt-2 mr-1\">Submission Deadline: #{l call.submission_deadline, format: :short } | Editing Deadline: #{l call.editing_deadline, format: :short }</span>".html_safe %>
+  <% if @proposals.present? %>
+    <% @proposals.each do |call, proposals| %>
+      <% div_name = "call_" + call.id.to_s + "_proposals" %>
+      <% title_right = "<span class=\"float-right mt-2 mr-1\">Submission Deadline: #{l call.submission_deadline, format: :short } | Editing Deadline: #{l call.editing_deadline, format: :short }</span>".html_safe %>
 
-    <%= render layout: '/shared/collapsible_section', locals: { id: div_name, title: call.name, title_right: title_right, header_class: 'p-0', body_class: "pt-1 pb-0" } do %>
-      <% proposals.each do |proposal| %>
-        <div>
-          <%= get_link proposal, :show %>
-          <%= proposal.labels true %>
-        </div>
+      <%= render layout: '/shared/collapsible_section', locals: { id: div_name, title: call.name, title_right: title_right, header_class: 'p-0', body_class: "pt-1 pb-0" } do %>
+        <% proposals.each do |proposal| %>
+          <div>
+            <%= get_link proposal, :show %>
+            <%= proposal.labels true %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
+  <% else %>
+    There are no proposals found for this search.
   <% end %>
 <% end %>
 

--- a/app/views/shared/_boolean_search_form_field.erb
+++ b/app/views/shared/_boolean_search_form_field.erb
@@ -1,1 +1,3 @@
-<%= f.input name.to_sym, label: label, input_html: { id: name, checked: params[name.to_sym] == "1" ? true : false, name: name }, as: :boolean %>
+<div class="col">
+    <%= f.input name.to_sym, label: label, input_html: { id: name, checked: params[name.to_sym] == "1" ? true : false, name: name }, as: :boolean %>
+</div>

--- a/app/views/shared/_date_range_search_form_field.erb
+++ b/app/views/shared/_date_range_search_form_field.erb
@@ -3,5 +3,10 @@
 <% start_date_attribute = 'start_date' if start_date_attribute.nil? %>
 <% end_date_attribute = 'end_date' if end_date_attribute.nil? %>
 
-<%= f.input "#{end_date_attribute}_gteq",   	as: :date, label: "Start Date", start_year: start_year, end_year: max_end_year, include_blank: true, required: false %>
-<%= f.input "#{start_date_attribute}_lteq",   as: :date, label: "End Date",   start_year: start_year, end_year: max_end_year, include_blank: true, required: false %>
+<div class="col">
+    <%= f.input "#{end_date_attribute}_gteq",   as: :date, label: "Start Date", start_year: start_year, end_year: max_end_year, include_blank: true, required: false %>
+</div>
+
+<div class="col">
+    <%= f.input "#{start_date_attribute}_lteq", as: :date, label: "End Date",   start_year: start_year, end_year: max_end_year, include_blank: true, required: false %>
+</div>

--- a/app/views/shared/_search_form.erb
+++ b/app/views/shared/_search_form.erb
@@ -7,11 +7,14 @@
 
   <% input_fields_in_collapse, input_fields_outside_collapse, button_params = split_search_form_input_fields(input_fields, columns) %>
 
+  <% # If there are less fields than columns, set the amount of columns to the amount of fields to optimise screen space. %>
+  <% columns = input_fields_outside_collapse.count if input_fields_in_collapse.empty? && input_fields_outside_collapse.count < columns %>
+
   <%= search_form_for(@q, builder: SimpleForm::FormBuilder, url: url, html: { id: "search" }, **horizontal_form_options) do |f| %>
     <div class="card-body">
       <%= render_search_form_fields(f, input_fields_outside_collapse, columns) %>
 
-      <% if input_fields_in_collapse.present? %>
+      <% if input_fields_in_collapse.any? %>
         <%= render layout: '/shared/collapsible_section', locals: { card_class: 'mb-0', title: 'More' } do %>
           <%= render_search_form_fields(f, input_fields_in_collapse, columns) %>
         <% end %>

--- a/app/views/shared/_search_form.erb
+++ b/app/views/shared/_search_form.erb
@@ -5,15 +5,15 @@
     <span class="card-title">Search</span>
   </div>
 
-  <% input_fields_in_collapse, input_fields_outside_collapse, button_params = split_search_form_input_fields(input_fields) %>
+  <% input_fields_in_collapse, input_fields_outside_collapse, button_params = split_search_form_input_fields(input_fields, columns) %>
 
   <%= search_form_for(@q, builder: SimpleForm::FormBuilder, url: url, html: { id: "search" }, **horizontal_form_options) do |f| %>
     <div class="card-body">
-      <%= render_search_form_fields(f, input_fields_outside_collapse) %>
+      <%= render_search_form_fields(f, input_fields_outside_collapse, columns) %>
 
       <% if input_fields_in_collapse.present? %>
         <%= render layout: '/shared/collapsible_section', locals: { card_class: 'mb-0', title: 'More' } do %>
-          <%= render_search_form_fields(f, input_fields_in_collapse) %>
+          <%= render_search_form_fields(f, input_fields_in_collapse, columns) %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/shared/pages/_index.erb
+++ b/app/views/shared/pages/_index.erb
@@ -2,9 +2,13 @@
 <% search_fields = nil if search_fields.nil? %>
 <% include_edit_button = true if include_edit_button.nil? %>
 <% include_link_to_item = true if include_link_to_item.nil? %>
-<% quick_actions = nil if quick_actions.nil? %>
+<% quick_actions = [] if quick_actions.nil? %>
 <% content = nil if content.nil? %>
 <% include_pagination = true if include_pagination.nil? %>
+
+<% if show_new_button && can?(:new, resource_class) %>
+  <% quick_actions << get_link(resource_class, :new) %>
+<% end %>
 
     <div class="row">
       <div class="col-md-7">
@@ -24,16 +28,15 @@
           <%= render 'shared/search_form', input_fields: search_fields %>
         <% end %>
 
-        <% if (show_new_button && can?(:new, resource_class)) || quick_actions.present? %>
+        <% if quick_actions.present? %>
           <div class="card">
             <div class="card-header">
               <span class="card-title">Quick actions</span>
             </div>
             <div class="card-body">
-              <% if show_new_button %>
-                <%= get_link resource_class, :new %>
+              <% quick_actions.each do |quick_action| %>
+                <%= quick_action %>
               <% end %>
-              <%= quick_actions %>
             </div>
           </div>
         <% end %>

--- a/app/views/shared/pages/_index.erb
+++ b/app/views/shared/pages/_index.erb
@@ -18,7 +18,7 @@
             <span class="card-title">Information</span>
           </div>
           <div class="card-body">
-            <%= display_block("#{resource_class.to_s.titleize} Admin Description", false) %>
+            <%= display_block(@editable_block_name, true) %>
           </div>
         </div>
       </div>

--- a/app/views/shared/pages/_index.erb
+++ b/app/views/shared/pages/_index.erb
@@ -31,7 +31,7 @@
       <div class="col">
 
         <% if search_fields.present? %>
-          <%= render 'shared/search_form', input_fields: search_fields %>
+          <%= render 'shared/search_form', input_fields: search_fields, columns: block_exists?(@editable_block_name) ? 1 : 2 %>
         <% end %>
 
         <% if quick_actions.present? %>

--- a/app/views/shared/pages/_index.erb
+++ b/app/views/shared/pages/_index.erb
@@ -11,17 +11,23 @@
 <% end %>
 
     <div class="row">
-      <div class="col-md-7">
-        <% # If you want to use this for front-end as well, you need to recognise if something is admin or not. %>
-        <div class="card">
-          <div class="card-header">
-            <span class="card-title">Information</span>
-          </div>
-          <div class="card-body">
-            <%= display_block(@editable_block_name, true) %>
+      <% if block_exists?(@editable_block_name) %>
+        <div class="col-md-7">
+          <% # If you want to use this for front-end as well, you need to recognise if something is admin or not. %>
+          <div class="card">
+            <div class="card-header">
+              <span class="card-title">Information</span>
+            </div>
+            <div class="card-body">
+              <%= display_block(@editable_block_name, true) %>
+            </div>
           </div>
         </div>
-      </div>
+        <% # Slightly bad to put it here, but essentially, if not rendering the block, add an "Create Block" button to the quick actions.%>
+      <% else %>
+        <% quick_actions << link_to_create_block(@editable_block_name) %>
+      <% end %>
+
       <div class="col">
 
         <% if search_fields.present? %>

--- a/app/views/shared/pages/public/_index.erb
+++ b/app/views/shared/pages/public/_index.erb
@@ -1,7 +1,7 @@
 <h1><%= @title %></h1>
 
 <div class="mb-3">
-  <%= display_block("Public Index - #{controller.class.to_s.underscore}", false) %>
+  <%= display_block(@editable_block_name, false) %>
 </div>
 
 <%= search_form %>
@@ -9,7 +9,7 @@
 <div class="row">
   <div class="col">
     <% if items.empty? %>
-      <%= display_block("Public Index - #{@title} - Empty", false) %>
+      <%= display_block("#{@editable_block_name} - No Resources", false) %>
     <% else %>
         <% items.each do |item| %>
           <div class="d-flex flex-column flex-md-row">

--- a/app/views/shared/pages/public/partials/_search_form.erb
+++ b/app/views/shared/pages/public/partials/_search_form.erb
@@ -1,4 +1,4 @@
 <% # Separate partial from the admin one just to prepare for the future. %>
 <div class="mb-3">
-  <%= render('shared/search_form', input_fields: search_fields) %>
+  <%= render('shared/search_form', input_fields: search_fields, columns: 2) %>
 </div>

--- a/test/functional/archives/proposals_controller_test.rb
+++ b/test/functional/archives/proposals_controller_test.rb
@@ -1,15 +1,24 @@
 require 'test_helper'
 
 class Archives::ProposalsControllerTest < ActionController::TestCase
-  test 'index' do
+  setup do
     sign_in users(:admin)
 
-    FactoryBot.create_list(:proposal, 10)
+    @proposals = FactoryBot.create_list(:proposal, 3)
+  end
 
+  test 'index' do
     get :index
     assert_response :success
+  end
 
+  test 'index with random' do
     get :index, params: { commit: 'Random' }
     assert_redirected_to admin_proposals_proposal_path(assigns(:proposal))
+  end
+
+  test 'index with a search for non-existent proposal' do
+    get :index, params: { q: { show_title_cont: 'this-show-title-will-never-exist' } }
+    assert_response :success
   end
 end

--- a/test/helpers/editable_block_helper_test.rb
+++ b/test/helpers/editable_block_helper_test.rb
@@ -29,10 +29,10 @@ class EditableBlockHelperTest < ActionView::TestCase
 
   test 'existing block should exist' do
     editable_block = FactoryBot.create :editable_block
-    assert block_exists(editable_block.name)
+    assert block_exists?(editable_block.name)
   end
 
   test 'non-existing block should not exist' do
-    assert_not block_exists('hexagon')
+    assert_not block_exists?('hexagon')
   end
 end

--- a/test/helpers/editable_block_helper_test.rb
+++ b/test/helpers/editable_block_helper_test.rb
@@ -24,7 +24,7 @@ class EditableBlockHelperTest < ActionView::TestCase
   end
 
   test 'should give warning for non-exising editable block' do
-    assert_equal 'Block not defined. <a href="/admin/editable_blocks/new?name=pineapple">Create Block</a>', display_block('pineapple', false)
+    assert_equal 'Block not defined. <a class="btn btn-primary my-1 mr-1" title="Create Editable Block" data-method="get" href="/admin/editable_blocks/new?name=pineapple"><span class="no-wrap"><i class="fas fa-align-left" aria-hidden=”true”></i> Create Editable Block</span></a>', display_block('pineapple', false)
   end
 
   test 'existing block should exist' do


### PR DESCRIPTION
# Fixes
- Turn quick actions for indices into an array instead of a string to prevent trying to append nil (fixes honeybadger report)
- Fix issue in rendering content blocks in indices when they are completely empty and thus nil by adding a 'no results found' text (honeybadger report)

# Additions
- Change shared index pages to use an editable block name set by the controller. This name is by default unique for each path which should prevent two indices using the same editable block, unless explicitly specified -> Fixes #179 
- Hide the information block in the admin index if there is no editable block for that index. -> Fixes #180 
- Columnise the search form to two columns if there is enough space.