### PR TITLE
Miscellaneous: devise views, membership activation tokens, default proposal text, limit team members to one per show/event combination

### DIFF
--- a/app/helpers/admin/staffings_helper.rb
+++ b/app/helpers/admin/staffings_helper.rb
@@ -3,6 +3,10 @@ module Admin::StaffingsHelper
   
   def check_if_current_user_can_sign_up(user, job = nil)
     can_sign_up = user.can?(:sign_up_for, Admin::StaffingJob)
+    
+    unless can_sign_up
+      append_to_flash(:error, 'You do not have the appropriate permission to sign up for staffing slots.')
+    end
 
     case job&.downcase
     when 'committee rep', 'committee', 'committee representative', 'cr'
@@ -18,7 +22,7 @@ module Admin::StaffingsHelper
     end
 
     unless user.phone_number.present?
-      append_to_flash(:error, 'You need to provide your phone number before you can sign up to staff. ')
+      append_to_flash(:error, 'You need to provide your phone number before you can sign up to staff.')
       can_sign_up = false
     end
 

--- a/app/models/admin/proposals/proposal.rb
+++ b/app/models/admin/proposals/proposal.rb
@@ -43,6 +43,8 @@ class Admin::Proposals::Proposal < ApplicationRecord
 
   accepts_nested_attributes_for :answers, :team_members, reject_if: :all_blank, allow_destroy: true
 
+  after_initialize :set_default_proposal_text
+
   # Reading is completely managed by ability.rb because it is so complicated and dependent on the call.
   DISABLED_PERMISSIONS = %w[read].freeze
 
@@ -188,4 +190,12 @@ class Admin::Proposals::Proposal < ApplicationRecord
     p "Slug: #{@show.slug}"
   end
   handle_asynchronously :convert_to_show
+
+  private
+
+  def set_default_proposal_text
+    return if !has_attribute?(:proposal_text) || proposal_text.present?
+
+    self.proposal_text = Admin::EditableBlock.find_by(name: 'Proposals - Proposal Text Default').try(:content) || ''
+  end
 end

--- a/app/models/membership_activation_token.rb
+++ b/app/models/membership_activation_token.rb
@@ -14,7 +14,7 @@
 require 'securerandom'
 
 class MembershipActivationToken < ApplicationRecord
-  belongs_to :user, optional: true
+  belongs_to :user
   before_validation :generate_token
 
   validates :token, uniqueness: { case_sensitive: false }, presence: true

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -19,7 +19,8 @@
 #++
 class TeamMember < ActiveRecord::Base
   validates :position, :user, presence: true
-
+  validates_uniqueness_of :user_id, scope: :teamwork_id
+  
   default_scope -> { order('position ASC') }
 
   # It should not be optional, but otherwise this fails on creation when immediately attaching team members.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -288,7 +288,7 @@ class User < ApplicationRecord
     end
   end
 
-
+  
   ## 
   # Roles
   # Overrides methods that only work on symbols to also work with the instance of the class.
@@ -328,7 +328,6 @@ class User < ApplicationRecord
   end
 
   def send_welcome_email
-    # TEST: It is not tested if the membership_activation_tokens controller and users controller calls to this method actually work.
     UsersMailer.welcome_email(self).deliver_later unless email.ends_with?('@bedlamtheatre.co.uk')
   end
 end

--- a/app/views/admin/membership_activation_tokens/new.html.erb
+++ b/app/views/admin/membership_activation_tokens/new.html.erb
@@ -3,8 +3,12 @@
         <%= simple_horizontal_form_for(@user, url: create_activation_admin_membership_activation_tokens_url, method: :post) do |f| %>
             <%= f.error_notification %>
 
-            <p>Enter the email of a new member here to send them an activation email.</p>
+            <p>Enter the details of a new member here to send them an activation email.</p>
+            
             <%= f.input :email %>
+            <%= f.input :first_name, required: true %>
+            <%= f.input :last_name, required: true %>
+
             <%= f.button :submit, "Send Activation", class: 'btn btn-primary' %>
         <% end %>
 

--- a/app/views/admin/proposals/proposals/_form.html.erb
+++ b/app/views/admin/proposals/proposals/_form.html.erb
@@ -10,8 +10,9 @@
 
     <%= display_block("Proposals - Help on Form", true) %>
 
-    <% if can?(:approve, @proposal) %>
-      <%= f.input :status %>
+    <% if can?(:approve, @proposal) && DateTime.current > @proposal.call.editing_deadline %>
+      <%= f.input :status, collection: Admin::Proposals::Proposal.statuses.keys, label_method: :humanize,
+              selected: Admin::Proposals::Proposal.statuses.keys[@proposal[:status].to_i] %>
     <% end %>
 
     <%= f.input :show_title %>

--- a/app/views/admin/roles/show.html.erb
+++ b/app/views/admin/roles/show.html.erb
@@ -1,6 +1,6 @@
 <% fields = { } %>
 
-<% if can? :assign_roles, User %>
+<% if current_user.has_role?('Admin') %>
   <% content_for :add_user do %>
     <% if @role.name.downcase == 'member' %>
       <% if can? :new, MembershipActivationToken %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -8,8 +8,8 @@
     <%= f.input :email, required: true, autofocus: true %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Resend confirmation instructions" %>
+  <div class="form-actions mb-3">
+    <%= f.button :submit, "Resend confirmation instructions", class: 'btn btn-primary' %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,9 +1,5 @@
 <% @hide_alert = true %>
 
-<% content_for :head do %>
-  <%= stylesheet_link_tag "login", :media => "all" %>
-<% end %>
-
 <div class="container">
   <div id="login_form" class="row">
     <div class="span4 offset4">
@@ -26,8 +22,8 @@
     <%= f.input :password_confirmation, label: "Confirm your new password", required: true %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Change my password" %>
+  <div class="form-actions mb-3">
+    <%= f.button :submit, "Change my password", class: 'btn btn-primary' %>
   </div>
 
       <% if params[:initial] then %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,8 +15,8 @@
     <%= f.input :current_password, hint: "we need your current password to confirm your changes", required: true %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Update" %>
+  <div class="form-actions mb-3">
+    <%= f.button :submit, "Update", class: 'btn btn-primary' %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,7 +17,7 @@
           <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
         </div>
 
-        <div class="form-actions">
+        <div class="form-actions mb-3">
           <%= f.button :submit, "Log in", class: "btn btn-primary"%>
         </div>
         <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Log in", new_session_path(resource_name), class: 'btn btn-primary' %><br />
 <% end -%>
 
 <%- if false #devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Register", new_registration_path(resource_name) %><br />
+  <%= link_to "Register", new_registration_path(resource_name), class: 'btn btn-secondary'  %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'btn btn-secondary' %><br />
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: 'btn btn-secondary'  %><br />
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: 'btn btn-secondary'  %><br />
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Log in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to "Log in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: 'btn btn-secondary'  %><br />
   <% end -%>
 <% end -%>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -8,8 +8,8 @@
     <%= f.input :email, required: true, autofocus: true %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Resend unlock instructions" %>
+  <div class="form-actions mb-3">
+    <%= f.button :submit, "Resend unlock instructions", class: 'btn btn-primary' %>
   </div>
 <% end %>
 

--- a/app/views/membership_activation_tokens/activate.html.erb
+++ b/app/views/membership_activation_tokens/activate.html.erb
@@ -7,7 +7,7 @@
 <%= simple_horizontal_form_for(@user, method: :patch, url: submit_membership_activation_token_path(@membership_activation_token)) do |f| %>
   <%= f.error_notification %>
 
-  <% unless @user.persisted? %>
+  <% if current_user.blank? %>
     <p>If you already have an account, please log in instead of completing this form twice. If you have problems logging in, please contact the Secretary at <a href="mailto:secretary@bedlamtheatre.co.uk">secretary@bedlamtheatre.co.uk</a></p>
   <% end %>
 

--- a/app/views/shared/form/_fields_for_template.erb
+++ b/app/views/shared/form/_fields_for_template.erb
@@ -2,6 +2,6 @@
 
 <% has_error = f.object.errors.any? %>
 
-<div class="<%= div_class_additions %> nested-fields<%= ' error' if has_error %>">
+<div class="<%= div_class_additions %> nested-fields mb-3<%= ' error' if has_error %>">
     <%= yield %>
 </div>

--- a/app/views/shared/form/_md_editor.html.erb
+++ b/app/views/shared/form/_md_editor.html.erb
@@ -9,7 +9,7 @@
     <% require "securerandom" %>
     <% id = SecureRandom.uuid %>
     <% show_hint = true if show_hint.nil? %>
-    <% hint = "Note: Text entered will be rendered using #{ link_to('kramdown', admin_help_kramdown_path, target: '_blank') }".html_safe if show_hint %>
+    <% hint = "Note: Text entered will be rendered using #{ link_to('kramdown', admin_help_kramdown_path, target: '_blank') }".html_safe %>
     <% rows ||= '10' %>
 
     <div class="row">

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+            <link rel="stylesheet" type="text/css" href="https://eutc.azureedge.net/styles/pretix-widget.css">
+            <script type="text/javascript" src="https://pretix.eu/widget/v1.en.js" async></script>
+<% end %>
+
 <div class="row">
   <div class="col-md-8">
     <%= render 'shared/carousel', id: 'homeCarousel', carousel_items: combine_events_with_carousel_items(@carousel_events, @standard_carousel_items) %>
@@ -27,12 +32,11 @@
       <div class="card mt-md-0 mt-sm-3">
         <div class="card-header"><h4>Book Now</h4></div>
         <div class="card-body">
-          <p class="card-text">
+          <div class="card-text">
             <%= display_block("Home - Book Now", false) %>
-            <link rel="stylesheet" type="text/css" href="https://eutc.azureedge.net/styles/pretix-widget.css">
-            <script type="text/javascript" src="https://pretix.eu/widget/v1.en.js" async></script>
+
             <pretix-widget event="https://tickets.bedlamtheatre.co.uk/" style="list"></pretix-widget>
-          </p>
+          </div>
         </div>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,16 +94,17 @@ ChaosRails::Application.routes.draw do
 
     resources :debt_notifications, only: [:index]
 
-    resources :staffing_debts do
+    resources :staffing_debts, except: [:destroy] do
       member do
-        put 'assign'
-        put 'unassign'
+        put 'convert_to_maintenance_debt'
+        put 'forgive'
       end
     end
 
-    resources :maintenance_debts do
+    resources :maintenance_debts, except: [:destroy] do
       member do
         put 'convert_to_staffing_debt'
+        put 'forgive'
       end
     end
 

--- a/db/migrate/20240601100725_add_unique_index_to_team_members.rb
+++ b/db/migrate/20240601100725_add_unique_index_to_team_members.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToTeamMembers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :team_members, [:teamwork_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_07_095731) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_01_100725) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -554,6 +554,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_07_095731) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "teamwork_type"
+    t.index ["teamwork_id", "user_id"], name: "index_team_members_on_teamwork_id_and_user_id", unique: true
     t.index ["teamwork_id"], name: "index_team_members_on_teamwork_id"
     t.index ["teamwork_type"], name: "index_team_members_on_teamwork_type"
     t.index ["user_id"], name: "index_team_members_on_user_id"

--- a/test/factories/team_member_factory.rb
+++ b/test/factories/team_member_factory.rb
@@ -18,5 +18,6 @@ FactoryBot.define do
     position { ['Director', 'Producer', 'Technical Manager', 'Stage Manager', 'Assistant to Mr B. Hussey'].sample }
     # The tests for the call run on the assumption that every team_member of a proposal is a member.
     association :user, factory: :member
+    association :teamwork, factory: :show
   end
 end

--- a/test/fixtures/admin/editable_blocks.yml
+++ b/test/fixtures/admin/editable_blocks.yml
@@ -26,6 +26,10 @@ event_members_only_text_default:
   name: "Event Members-Only Text Default"
   content: "This is the default text for the members-only text field."
 
+proposals_proposal_text_default:
+  name: "Proposals - Proposal Text Default"
+  content: "This is the default text for the proposal text field."
+
 welcome email:
   name: "Email - Welcome Email"
   content: "This is the test welcome email content"
@@ -34,3 +38,8 @@ about:
   name: about
   url: about
   content: 'This is the about page'
+
+archive_help_page:
+  name: archive_help_page
+  url: archives/help
+  content: 'This is the archive help page'

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -33,3 +33,9 @@ admin:
 welfare:
   id: 4
   name: "Welfare Contact"
+
+dm_trained:
+  name: "DM Trained"
+
+first_aid_trained:
+  name: "First Aid Trained"

--- a/test/functional/admin/shows_controller_test.rb
+++ b/test/functional/admin/shows_controller_test.rb
@@ -112,7 +112,7 @@ class Admin::ShowsControllerTest < ActionController::TestCase
   test 'should update show without new debtors' do
     @show = FactoryBot.create(:show)
 
-    users = FactoryBot.create_list(:user, 5) + @show.users
+    users = FactoryBot.create_list(:user, 3)
     attributes = FactoryBot.attributes_for(:show, team_members_attributes: team_members_attributes(users))
 
     # To check if an existing user who is in debt does not count.
@@ -122,6 +122,7 @@ class Admin::ShowsControllerTest < ActionController::TestCase
       put :update, params: { id: @show, show: attributes }
     end
 
+    assert_empty assigns(:show).errors.full_messages, 'There are errors on the show'
     assert_equal ["The Show \"#{attributes[:name]}\" was successfully updated."], flash[:success]
 
     assert_redirected_to admin_show_path(assigns(:show))

--- a/test/functional/admin/static_controller_test.rb
+++ b/test/functional/admin/static_controller_test.rb
@@ -2,12 +2,23 @@ require 'test_helper'
 
 class Admin::StaticControllerTest < ActionController::TestCase
   test 'committee can get committee' do
+    sign_in users(:committee)
+    
     get :committee
+    assert_response :success
   end
 
   test 'non committee cannot get committee' do
     sign_in users(:member)
 
     get :committee
+    assert_response :forbidden
+  end
+
+  test 'error static page' do
+    sign_in users(:admin)
+
+    get :error, params: { page: 'pineapple' }
+    assert_response 404
   end
 end

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -32,8 +32,13 @@ class Admin::UsersControllerTest < ActionController::TestCase
   test 'should create user' do
     attributes = FactoryBot.attributes_for(:user)
 
-    assert_difference('User.count') do
-      post :create, params: { user: attributes }
+    # Test the welcome email is send.
+    assert_difference 'ActionMailer::Base.deliveries.count' do
+      perform_enqueued_jobs do
+        assert_difference('User.count') do
+          post :create, params: { user: attributes }
+        end
+      end
     end
 
     assert_redirected_to admin_user_path(assigns(:user))

--- a/test/functional/archives_controller_test.rb
+++ b/test/functional/archives_controller_test.rb
@@ -5,4 +5,9 @@ class ArchivesControllerTest < ActionController::TestCase
     get :index
     assert_response :success
   end
+
+  test 'should get page' do
+    get :page, params: { page: 'help' }
+    assert_response :success
+  end
 end

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -84,8 +84,9 @@ class AttachmentsControllerTest < ActionController::TestCase
   test 'someone not on the proposal should be able to view an attachment on an approved proposal after the editing deadline' do
     sign_in users(:member)
 
-    proposal = FactoryBot.create(:proposal, status: :approved, submission_deadline: -1.days.from_now )
-    
+    proposal = FactoryBot.create(:proposal, status: :approved, submission_deadline: -1.days.from_now)
+    proposal.call.update(editing_deadline: proposal.call.submission_deadline.advance(hours: 1))
+
     question = FactoryBot.create(:question, questionable: proposal, answered: true, response_type: 'File')
     attachment = question.answers.first.attachments.first
     attachment.save(access_level: 1)

--- a/test/functional/membership_activation_tokens_controller_test.rb
+++ b/test/functional/membership_activation_tokens_controller_test.rb
@@ -88,7 +88,12 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
     user_attributes = FactoryBot.attributes_for(:user)
 
     assert_no_difference 'User.count' do
-      patch :submit, params: { id: @token, user: user_attributes, consent: 'true' }
+      # Test the welcome email is send. It also sends a 'password changed' email, which is why the count should be 2.
+      assert_difference 'ActionMailer::Base.deliveries.count', 2 do
+        perform_enqueued_jobs do
+          patch :submit, params: { id: @token, user: user_attributes, consent: 'true' }
+        end
+      end
 
       assert_nil flash[:error]
       assert_redirected_to admin_url
@@ -105,7 +110,13 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
     user_attributes = FactoryBot.attributes_for(:user)
 
     assert_no_difference 'User.count' do
-      patch :submit, params: { id: @token, user: user_attributes, consent: 'true' }
+      # Test the welcome email is send again. It also sends a 'password changed' email, which is why the count should be 2.
+      assert_difference 'ActionMailer::Base.deliveries.count', 2 do
+        perform_enqueued_jobs do
+          patch :submit, params: { id: @token, user: user_attributes, consent: 'true' }
+          
+        end
+      end
 
       assert_nil flash[:error]
       assert_redirected_to admin_url

--- a/test/functional/membership_activation_tokens_controller_test.rb
+++ b/test/functional/membership_activation_tokens_controller_test.rb
@@ -1,8 +1,13 @@
 require 'test_helper'
 
+# TIP: If you get a forbidden error in any of these, that is because get_user raised an error.
+
 class MembershipActivationTokensControllerTest < ActionController::TestCase
   setup do
-    @token = MembershipActivationToken.create
+    user = users(:user)
+    user.update(consented: nil)
+
+    @token = MembershipActivationToken.create(user: user)
   end
 
   test 'get activate for new user' do
@@ -10,11 +15,12 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
 
     get :activate, params: { id: @token }
 
+    assert_nil flash[:error]
     assert_response :success
 
     # I was not quite sure how to best test that the user form is present, so I'm just testing if the hint is present.
     assert_match 'If you already have an account, please log in instead of completing this form twice.', response.body
-    assert_not assigns(:user).persisted?
+    assert_not assigns(:user).saved_changes?
   end
 
   test 'get activate for existing user' do
@@ -25,6 +31,7 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
 
     get :activate, params: { id: @token }
 
+    assert_nil flash[:error]
     assert_response :success
 
     # I was not quite sure how to best test that the user form is present, so I'm just testing if the hint is absent.
@@ -33,12 +40,14 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
   end
 
   test 'cannot get activate when logged in while the token does not have an user' do
+    @token.update_attribute(:user, nil)
+
     sign_in FactoryBot.create(:member)
 
     get :activate, params: { id: @token }
 
     assert_response 403
-    assert_equal ['This token belongs to a new user, but you are already logged in.'], flash[:error]
+    assert_equal ['This token belongs to a new user, but you are already logged in. You are not allowed to activate this account.'], flash[:error]
   end
 
   test 'cannot get activate when logged in as the wrong user' do
@@ -49,10 +58,10 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
     get :activate, params: { id: @token }
 
     assert_response 403
-    assert_equal ['This token belongs to a different user.'], flash[:error]
+    assert_equal ['This token belongs to a different user. You are not allowed to activate this account.'], flash[:error]
   end
 
-  test 'cannot get activate when the user thatthe token belongs to is logged in as member' do
+  test 'cannot get activate when the user that the token belongs to is logged in as member' do
     member = FactoryBot.create(:member)
     sign_in member
 
@@ -73,13 +82,16 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
     assert_equal ['This token belongs to an existing user, but you are not logged in. Please log in and try again.'], flash[:error]
   end
 
-  test 'submit for new member' do
+  test 'submit for new member without being signed in' do
     # No account, so no sign in
 
     user_attributes = FactoryBot.attributes_for(:user)
 
-    assert_difference 'User.count' do
+    assert_no_difference 'User.count' do
       patch :submit, params: { id: @token, user: user_attributes, consent: 'true' }
+
+      assert_nil flash[:error]
+      assert_redirected_to admin_url
 
       assert_not_nil assigns(:user)
       assert assigns(:user).has_role?('Member')
@@ -87,16 +99,16 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
     end
   end
 
-  test 'submit for existing user' do
-    user = FactoryBot.create(:user)
-
-    @token.update_attribute(:user, user)
-    sign_in user
+  test 'submit for existing user when signed in' do
+    sign_in @token.user
 
     user_attributes = FactoryBot.attributes_for(:user)
 
     assert_no_difference 'User.count' do
       patch :submit, params: { id: @token, user: user_attributes, consent: 'true' }
+
+      assert_nil flash[:error]
+      assert_redirected_to admin_url
 
       assert_not_nil assigns(:user)
       assert assigns(:user).has_role?('Member')
@@ -109,25 +121,25 @@ class MembershipActivationTokensControllerTest < ActionController::TestCase
 
     patch :submit, params: { id: @token, user: user_attributes }
 
-    assert_response :unprocessable_entity
     assert_equal ['You need to accept the Terms and Conditions before continuing.'], flash[:error]
+    assert_response :unprocessable_entity
 
     assert_not_nil assigns(:user)
-    assert_not assigns(:user).persisted?
+    assert_not assigns(:user).saved_changes?
 
     # The user form has to be present, even though a user is passed, but this user has not persisted yet.
     assert_match 'If you already have an account, please log in instead of completing this form twice.', response.body
   end
 
   test 'cannot submit with invalid user attributes' do
-    user_attributes = FactoryBot.attributes_for(:user, email: nil)
+    user_attributes = FactoryBot.attributes_for(:user, email: nil, first_name: 'Pineapple')
 
     patch :submit, params: { id: @token, user: user_attributes, consent: 'true' }
 
-    assert_response :unprocessable_entity
     assert_nil flash[:error]
+    assert_response :unprocessable_entity
 
     assert_not_nil assigns(:user)
-    assert_not assigns(:user).persisted?
+    assert_not assigns(:user).saved_changes?
   end
 end

--- a/test/helpers/team_member_helper_test.rb
+++ b/test/helpers/team_member_helper_test.rb
@@ -1,7 +1,78 @@
 require 'test_helper'
 
 class TeamMemberHelperTest < ActionView::TestCase
-  test 'star rating' do
-    assert false
+  setup do
+    @team_member = FactoryBot.create(:team_member)
+  end
+
+  test 'DM trained user should have the DM trained label' do
+    assert_not @team_member.user.has_role?("DM Trained")
+    assert_not_includes team_member_labels_for(@team_member, Date.current).join(';'), 'DM Trained'
+
+    @team_member.user.add_role("DM Trained")
+    assert_includes team_member_labels_for(@team_member, Date.current).join(';'), 'DM Trained'
+  end
+
+  test 'First Aid Trained user should have the First Aid Trained label' do
+    assert_not @team_member.user.has_role?("First Aid Trained")
+    assert_not_includes team_member_labels_for(@team_member, Date.current).join(';'), 'First Aid Trained'
+
+    @team_member.user.add_role("First Aid Trained")
+    assert_includes team_member_labels_for(@team_member, Date.current).join(';'), 'First Aid Trained'
+  end
+
+  test 'Show in this academic year should warn for non-member' do
+    @team_member.teamwork.update(start_date: Date.current, end_date: Date.current + 1.days)
+
+    @team_member.user.remove_role("Member")
+    labels = team_member_labels_for(@team_member, nil).map { |l| l[:text] }
+    assert_includes labels, 'Not A Member'
+  end
+  
+  test 'shows in previous academic years should not warn for non-members' do
+    @team_member.teamwork.update(start_date: 1.year.ago , end_date: 1.year.ago + 1.days)
+
+    @team_member.user.remove_role("Member")
+    labels = team_member_labels_for(@team_member, nil).map { |l| l[:text] }
+    assert_not_includes labels, 'Not A Member'
+  end
+  
+  test 'user in staffing debt on deadline' do
+    FactoryBot.create(:overdue_staffing_debt, user: @team_member.user)
+
+    deadline = 1.week.from_now.to_date
+
+    label = team_member_labels_for(@team_member, deadline).first
+
+    assert_includes label[:text], "In staffing Debt"
+    assert_equal :danger, label[:label_class]
+  end
+  
+  test 'user in maintenance debt on deadline' do
+    FactoryBot.create(:overdue_maintenance_debt, user: @team_member.user)
+
+    deadline = 1.week.from_now.to_date
+
+    label = team_member_labels_for(@team_member, deadline).first
+
+    assert_includes label[:text], "In maintenance Debt"
+    assert_equal :danger, label[:label_class]
+  end
+
+  test 'user is in staffing debt and not in maintenace debt now but is on the editing deadline' do
+    FactoryBot.create(:overdue_staffing_debt, user: @team_member.user)
+    FactoryBot.create(:maintenance_debt, user: @team_member.user, due_by: 5.days.from_now)
+
+    deadline = 1.week.from_now.to_date
+
+    labels = team_member_labels_for(@team_member, deadline)
+
+    assert_equal 2, labels.count
+
+    assert_includes labels.first[:text], "In staffing Debt"
+    assert_equal :danger, labels.first[:label_class]
+
+    assert_includes labels.last[:text], "In staffing and maintenance Debt on the editing deadline"
+    assert_equal :danger, labels.last[:label_class]
   end
 end

--- a/test/models/admin/proposals/proposal_test.rb
+++ b/test/models/admin/proposals/proposal_test.rb
@@ -24,6 +24,11 @@ class Admin::Proposals::ProposalTest < ActiveSupport::TestCase
     @proposal = FactoryBot.create(:proposal, call: @call)
   end
 
+  test 'set default proposal text' do
+    proposal = Admin::Proposals::Proposal.new
+    assert proposal.proposal_text.present?
+  end
+
   test 'instantiate_answers' do
     @proposal.questions.clear
 

--- a/test/models/show_test.rb
+++ b/test/models/show_test.rb
@@ -58,7 +58,7 @@ class ShowTest < ActiveSupport::TestCase
     show = FactoryBot.create(:show, maintenance_debt_start: due_by)
 
     assert_difference('Admin::MaintenanceDebt.count', show.users.count) do
-    show.create_maintenance_debts
+      show.create_maintenance_debts
     end
 
     # Assert each user has a maintenance debt.
@@ -77,7 +77,7 @@ class ShowTest < ActiveSupport::TestCase
     # Test that the new user also gets a maintenance debt, but the other users do not get an extra one.
 
     assert_difference('Admin::MaintenanceDebt.count', 1) do
-    show.create_maintenance_debts
+      show.create_maintenance_debts
     end
 
     show.users.each do |user|
@@ -150,6 +150,17 @@ class ShowTest < ActiveSupport::TestCase
     show.create_staffing_debts(3)
 
     assert_equal 4, user.admin_staffing_debts.count
+  end
+
+  test 'cannot add user to the same show twice as team member' do
+    show = FactoryBot.create(:show, team_member_count: 1)
+    current_team_member = show.team_members.first
+
+    assert_no_difference('TeamMember.count') do
+      assert_raises ActiveRecord::RecordInvalid do
+        show.team_members.create!(user: current_team_member.user)
+      end
+    end
   end
 
   test 'as_json' do


### PR DESCRIPTION
# Features
- Limit team members to only one per user/event combination to prevent duplicates.
- 
# Changes
- Always show the tiny hint on the MD input field.
- Add bottom margins to the fields_for template
- Add tests for if emails are sent on account creation, archives static pages, admin static controller, and staffing phone checks.

# Fixes
- Remove unnecessary whitespace around the book now widget.
- Fix condition on showing add user on roles pages
- Fix status field on proposals to be a select
- Add some things I forgot for staffing and maintenance.