### PR TITLE
Questionnaire Notifications

### DIFF
--- a/app/assets/stylesheets/shared_additions.scss.erb
+++ b/app/assets/stylesheets/shared_additions.scss.erb
@@ -20,6 +20,7 @@
   margin: 0px;
 }
 
+/* BOOTSTRAP 5: float-left and float-right deprecated. Check everywhere */
 img.float-left, img.float-right {
   @extend .img-fluid !optional;
   max-width: 192px;

--- a/app/controllers/admin/questionnaires/questionnaire_templates_controller.rb
+++ b/app/controllers/admin/questionnaires/questionnaire_templates_controller.rb
@@ -23,7 +23,7 @@ class Admin::Questionnaires::QuestionnaireTemplatesController < AdminController
   end
 
   def permitted_params
-    [:name, questions_attributes: [:id, :_destroy, :question_text, :response_type]]
+    [:name, questions_attributes: [:id, :_destroy, :question_text, :response_type], notify_emails_attributes: [:id, :_destroy, :email]]
   end
 
   def edit_title

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -14,8 +14,8 @@ module LinkHelper
   end
 
   def link_to_add(form, attribute_name, object_name: nil, html_class: nil)
-    html_class ||= 'btn btn-secondary'
     object_name ||= format_class_name(attribute_name.to_s, true)
+    html_class ||= "btn btn-secondary #{object_name.parameterize.underscore}_add_button"
 
     # Important 'link_to_add_association"-fact: It goes up two divs, and then adds it to the end. This is why it is wrapped in a div here.
     # If you want to put it in a div yourself for whatever reason, you have to make that wrapping optional.

--- a/app/mailers/questionnaires_mailer.rb
+++ b/app/mailers/questionnaires_mailer.rb
@@ -1,0 +1,16 @@
+class QuestionnairesMailer < ApplicationMailer
+  include NameHelper
+
+  default reply_to: 'IT <it@bedlamtheatre.co.uk>'
+
+  # Notifies all notify_emails on the questionnaire that there was an update.
+  def notify(questionnaire, submitter, recipient_notify_email)
+    @submitter = submitter
+
+    @subject = "#{get_object_name(questionnaire, include_class_name: true)} updated by #{submitter.name}"
+    @questionnaire_name = get_object_name(questionnaire, include_class_name: true, include_the: true)
+    @questionnaire = questionnaire
+
+    mail(to: recipient_notify_email.email, subject: @subject)
+  end
+end

--- a/app/models/admin/questionnaires/questionnaire.rb
+++ b/app/models/admin/questionnaires/questionnaire.rb
@@ -22,9 +22,11 @@ class Admin::Questionnaires::Questionnaire < ApplicationRecord
   has_many :answers, as: :answerable
   has_many :team_members, through: :event
   has_many :users, through: :team_members
+  has_many :notify_emails, class_name: 'Email', as: :attached_object, dependent: :destroy
 
   accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :answers, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :notify_emails, reject_if: :all_blank, allow_destroy: true
 
   def self.ransackable_attributes(auth_object = nil)
     %w[name]

--- a/app/models/admin/questionnaires/questionnaire_template.rb
+++ b/app/models/admin/questionnaires/questionnaire_template.rb
@@ -18,18 +18,21 @@ class Admin::Questionnaires::QuestionnaireTemplate < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   has_many :questions, as: :questionable
+  has_many :notify_emails
+  has_many :notify_emails, class_name: 'Email', as: :attached_object, dependent: :destroy
 
   accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :notify_emails, reject_if: :all_blank, allow_destroy: true
 
   def as_json(options = {})
-    defaults = { include: [:questions] }
+    defaults = { include: [:questions, :notify_emails] }
 
     options = merge_hash(defaults, options)
 
     super(options)
   end
 
-  def self.ransackable_attributes(auth_object = nil)
+def self.ransackable_attributes(auth_object = nil)
     %w[name]
   end
 

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,0 +1,7 @@
+class Email < ApplicationRecord
+  belongs_to :attached_object, polymorphic: true, optional: false
+  validates :email, presence: true
+
+  # No duplicate emails on the same attached_object.
+  validates_uniqueness_of :email, scope: :attached_object_id
+end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -19,7 +19,7 @@
 #++
 class TeamMember < ActiveRecord::Base
   validates :position, :user, presence: true
-  validates_uniqueness_of :user_id, scope: :teamwork_id
+  validates_uniqueness_of :user_id, scope: [:teamwork_type, :teamwork_id]
   
   default_scope -> { order('position ASC') }
 

--- a/app/views/admin/questionnaires/questionnaire_templates/_form.html.erb
+++ b/app/views/admin/questionnaires/questionnaire_templates/_form.html.erb
@@ -2,6 +2,9 @@
   <%= render('shared/pages/form', f: f) do %>
     <%= f.input :name %>
 
+    <h3>Notify Emails</h3>
+    <%= render('shared/form/sections/nested_fields', f: f, association_name: :notify_emails, partial_name: 'notify_email_fields') %>
+
     <div name="questions">
       <h3>Questions</h3>
       <%= render('shared/form/md_hints') %>

--- a/app/views/admin/questionnaires/questionnaire_templates/show.html.erb
+++ b/app/views/admin/questionnaires/questionnaire_templates/show.html.erb
@@ -1,5 +1,5 @@
 <% fields = {
-  emails: @questionnaire_template.notify_emails.pluck(:email).to_sentence || 'No emails set',
+  notify_emails: @questionnaire_template.notify_emails.pluck(:email).to_sentence.presence || 'No notify emails set',
 } %>
 
 <% @questionnaire_template.questions.each do |question| %>

--- a/app/views/admin/questionnaires/questionnaire_templates/show.html.erb
+++ b/app/views/admin/questionnaires/questionnaire_templates/show.html.erb
@@ -1,4 +1,6 @@
-<% fields = {} %>
+<% fields = {
+  emails: @questionnaire_template.notify_emails.pluck(:email).to_sentence || 'No emails set',
+} %>
 
 <% @questionnaire_template.questions.each do |question| %>
   <% fields[question.id] = { type: 'content', content: render('/shared/question_template_show', question: question) } %>

--- a/app/views/admin/questionnaires/questionnaires/_form.html.erb
+++ b/app/views/admin/questionnaires/questionnaires/_form.html.erb
@@ -21,6 +21,9 @@
 
     <%= f.input :name %>
 
+    <h3>Notify Emails</h3>
+    <%= render('shared/form/sections/nested_fields', f: f, association_name: :notify_emails, partial_name: 'notify_email_fields') %>
+
     <div id="questions">
       <h3>Questions</h3>
       <%= render('shared/form/md_hints') %>

--- a/app/views/admin/questionnaires/questionnaires/answer.html.erb
+++ b/app/views/admin/questionnaires/questionnaires/answer.html.erb
@@ -7,5 +7,15 @@
 
       <%= render('shared/form/sections/nested_fields', f: f, association_name: :answers, partial_name: 'answer_fields', display_link_to_add: false) %>
     </div>
+
+    <% if @questionnaire.notify_emails.any? %>
+      <% content_for :extra_form_actions do %>
+        <%= f.button(:submit, 'Submit and Notify', params: { notify: 1 }, class: 'btn-success') if @questionnaire.notify_emails.any? %>
+      <% end %>
+
+      <p class="text-muted">Only use the 'Submit and Notify' button once you want the committee to chek your questionnaire, or you have made significant changes to your questionnaire. Pressing this button multiple times will not make committee check your questionnaire any quicker.</p>
+    <% else %>
+      <p class="text-muted">This questionnaire has no emails attached to notify when the questionnaire is completed. Please let the committee member responsible for checking the questionnaire know when it has been completed.</p>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/admin/questionnaires/questionnaires/show.html.erb
+++ b/app/views/admin/questionnaires/questionnaires/show.html.erb
@@ -1,6 +1,6 @@
 <% fields = {
   event: get_link(@questionnaire.event, :show),
-  emails: @questionnaire.notify_emails.pluck(:email).to_sentence || 'No emails set',
+  notify_emails: @questionnaire.notify_emails.pluck(:email).to_sentence.presence || 'No notify emails set',
   questions_and_answers: { type: 'content', header: 'Questions', content: render('/shared/questions_and_answers', answers: @questionnaire.answers) }
 } %>
 

--- a/app/views/admin/questionnaires/questionnaires/show.html.erb
+++ b/app/views/admin/questionnaires/questionnaires/show.html.erb
@@ -1,5 +1,6 @@
 <% fields = {
   event: get_link(@questionnaire.event, :show),
+  emails: @questionnaire.notify_emails.pluck(:email).to_sentence || 'No emails set',
   questions_and_answers: { type: 'content', header: 'Questions', content: render('/shared/questions_and_answers', answers: @questionnaire.answers) }
 } %>
 

--- a/app/views/application/_notify_email_fields.erb
+++ b/app/views/application/_notify_email_fields.erb
@@ -1,0 +1,7 @@
+<%= render '/shared/form/inline_fields_for_template',
+    f: f,
+    div_class_additions: 'email',
+    fields: [
+        { field: f.hidden_field(:id) + f.input(:email) },
+        { field: link_to_remove(f), col_modifier: 'auto' },
+] %>

--- a/app/views/questionnaires_mailer/notify.html.erb
+++ b/app/views/questionnaires_mailer/notify.html.erb
@@ -1,0 +1,11 @@
+<% url = admin_questionnaires_questionnaire_url(@questionnaire) %>
+
+<p>Hi there,<p>
+
+<p><%= @questionnaire_name %> has been updated by <%= @submitter.name %>, and they wanted to notify you of this.<p>
+
+<p>Please check the questionnaire at <%= link_to url, url %>, and get back to <%= @submitter.first_name %> if necessary.</p>
+
+<p>With best wishes,</p>
+
+<p>Pineapple</p>

--- a/app/views/questionnaires_mailer/notify.text.erb
+++ b/app/views/questionnaires_mailer/notify.text.erb
@@ -1,0 +1,9 @@
+Hi there,
+
+<%= @questionnaire_name %> has been updated by <%= @submitter.name %>, and they wanted to notify you of this.
+
+Please check the questionnaire at <%= admin_questionnaires_questionnaire_url(@questionnaire) %>, and get back to <%= @submitter.first_name %> if necessary.
+
+With best wishes,
+
+Pineapple

--- a/db/migrate/20240610101949_create_emails.rb
+++ b/db/migrate/20240610101949_create_emails.rb
@@ -1,4 +1,4 @@
-class CreateEmails < ActiveRecord::Migration[7.1]
+class CreateEmails < ActiveRecord::Migration[7.0]
   def change
     create_table :emails do |t|
       t.string :email
@@ -6,7 +6,7 @@ class CreateEmails < ActiveRecord::Migration[7.1]
 
       t.timestamps
 
-      t.index [:email, :attached_object_id], unique: true
+      t.index [:email, :attached_object_id, :attached_object_type], unique: true, name: 'index_emails_on_email_and_attached_object'
     end
   end
 end

--- a/db/migrate/20240610101949_create_emails.rb
+++ b/db/migrate/20240610101949_create_emails.rb
@@ -1,0 +1,12 @@
+class CreateEmails < ActiveRecord::Migration[7.1]
+  def change
+    create_table :emails do |t|
+      t.string :email
+      t.references :attached_object, null: false, polymorphic: true, index: true
+
+      t.timestamps
+
+      t.index [:email, :attached_object_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_01_100725) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_10_101949) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -91,7 +91,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_01_100725) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "state", default: 0
     t.bigint "maintenance_attendance_id"
-    t.boolean "converted_from_staffing_debt", default: false
+    t.boolean "converted_from_staffing_debt", default: false, null: false
     t.index ["maintenance_attendance_id"], name: "index_admin_maintenance_debts_on_maintenance_attendance_id"
   end
 
@@ -168,7 +168,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_01_100725) do
     t.integer "admin_staffing_job_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.boolean "converted_from_maintenance_debt", default: false
+    t.boolean "converted_from_maintenance_debt", default: false, null: false
     t.bigint "state", default: 0, null: false
   end
 
@@ -274,6 +274,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_01_100725) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "description"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "emails", charset: "utf8mb3", force: :cascade do |t|
+    t.string "email"
+    t.string "attached_object_type", null: false
+    t.bigint "attached_object_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["attached_object_type", "attached_object_id"], name: "index_emails_on_attached_object"
+    t.index ["email", "attached_object_id"], name: "index_emails_on_email_and_attached_object_id", unique: true
   end
 
   create_table "event_tags", charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -283,7 +283,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_10_101949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["attached_object_type", "attached_object_id"], name: "index_emails_on_attached_object"
-    t.index ["email", "attached_object_id"], name: "index_emails_on_email_and_attached_object_id", unique: true
+    t.index ["email", "attached_object_id", "attached_object_type"], name: "index_emails_on_email_and_attached_object", unique: true
   end
 
   create_table "event_tags", charset: "utf8mb3", force: :cascade do |t|

--- a/test/factories/admin/questionnaires/questionnaire_factory.rb
+++ b/test/factories/admin/questionnaires/questionnaire_factory.rb
@@ -20,7 +20,8 @@ FactoryBot.define do
     end
 
     after(:create) do |questionnaire, _evaluator|
-      questions = FactoryBot.create_list(:question, 10, questionable: questionnaire)
+      questions = FactoryBot.create_list(:question, 5, questionable: questionnaire)
+      emails = FactoryBot.create_list(:email, 2, attached_object: questionnaire)
     end
   end
 end

--- a/test/factories/email_factory.rb
+++ b/test/factories/email_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :email do
+    email { Faker::Internet.email }
+    association :attached_object, factory: :questionnaire
+  end
+end

--- a/test/fixtures/emails.yml
+++ b/test/fixtures/emails.yml
@@ -1,0 +1,14 @@
+notify_email_one:
+  attached_object_id: 1
+  attached_object_type: Admin::Questionnaires::QuestionnaireTemplate
+  email: alice@template.test
+
+notify_email_two:
+  attached_object_id: 1
+  attached_object_type: Admin::Questionnaires::QuestionnaireTemplate
+  email: bob@template.test
+
+notify_email_three:
+  attached_object_id: 1
+  attached_object_type: Admin::Questionnaires::QuestionnaireTemplate
+  email: charlie@template.test

--- a/test/functional/mailers/questionnaires_mailer_test.rb
+++ b/test/functional/mailers/questionnaires_mailer_test.rb
@@ -1,0 +1,5 @@
+require 'test_helper'
+
+class QuestionnairesMailerTest < ActionMailer::TestCase
+  # Tests are done in the controller test instead because it needs to test the whole action implementation.
+end

--- a/test/mailers/previews/questionnaires_mailer_preview.rb
+++ b/test/mailers/previews/questionnaires_mailer_preview.rb
@@ -1,0 +1,7 @@
+class QuestionnairesMailerPreview < ActionMailer::Preview
+  def notify
+    questionnaire = Admin::Questionnaires::Questionnaire.where.not(notify_emails: nil).sample || FactoryBot.create(:questionnaire)
+
+    QuestionnairesMailer.notify(questionnaire)
+  end
+end

--- a/test/models/email_test.rb
+++ b/test/models/email_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EmailTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# Features
- Add notify emails to questionnaires. When saving questionnaire answers, the submitter can click a button to notify a list of 'notify emails' specified on the questionnaire by the creator of the questionnaire (or loaded from a template). This way, committee members do not constantly need to check if questionnaires have been completed.

# Changes

# Fixes
- Fix the uniqueness validation on team_members, as it did not take teamwork type into account. This meant that if you wanted to add the same person to a proposal with ID 5 and to an event with ID 5, it wouldn't let you, even though it was not actually a duplicate.