### PR TITLE
Add normalizations, and fix some packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem 'stringex'
 
 gem 'honeybadger'
 
+gem 'csv'
+
 group :development, :test do
   # Use Puma as the app server
   gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,6 +493,7 @@ DEPENDENCIES
   cocoon
   coffee-rails
   coffee-script-source (= 1.12.2)
+  csv
   daemons
   delayed_job_active_record
   devise

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -13,3 +13,5 @@
 
 //= link jquery.fancybox.css
 //= link jquery.fancybox.js
+
+//= link select2.js

--- a/app/models/admin/editable_block.rb
+++ b/app/models/admin/editable_block.rb
@@ -30,6 +30,8 @@ class Admin::EditableBlock < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :url, uniqueness: { case_sensitive: false }, if: :url?
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def self.groups
     select('`group`').distinct.map(&:group).reject(&:blank?)
   end

--- a/app/models/admin/proposals/call.rb
+++ b/app/models/admin/proposals/call.rb
@@ -29,6 +29,8 @@ class Admin::Proposals::Call < ApplicationRecord
 
   accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   # TODO: Maybe revise what open means?
   scope :open, -> { where(submission_deadline: DateTime.now..DateTime::Infinity.new) }
 

--- a/app/models/admin/proposals/call_question_template.rb
+++ b/app/models/admin/proposals/call_question_template.rb
@@ -20,6 +20,8 @@ class Admin::Proposals::CallQuestionTemplate < ApplicationRecord
   has_many :questions, as: :questionable
   accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def as_json(options = {})
     defaults = { include: [:questions] }
 

--- a/app/models/admin/proposals/proposal.rb
+++ b/app/models/admin/proposals/proposal.rb
@@ -45,6 +45,8 @@ class Admin::Proposals::Proposal < ApplicationRecord
 
   after_initialize :set_default_proposal_text
 
+  normalizes :show_title, with: -> (show_title) { show_title&.strip }
+
   # Reading is completely managed by ability.rb because it is so complicated and dependent on the call.
   DISABLED_PERMISSIONS = %w[read].freeze
 

--- a/app/models/admin/questionnaires/questionnaire.rb
+++ b/app/models/admin/questionnaires/questionnaire.rb
@@ -28,6 +28,8 @@ class Admin::Questionnaires::Questionnaire < ApplicationRecord
   accepts_nested_attributes_for :answers, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :notify_emails, reject_if: :all_blank, allow_destroy: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[name]
   end

--- a/app/models/admin/questionnaires/questionnaire_template.rb
+++ b/app/models/admin/questionnaires/questionnaire_template.rb
@@ -24,6 +24,8 @@ class Admin::Questionnaires::QuestionnaireTemplate < ApplicationRecord
   accepts_nested_attributes_for :questions, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :notify_emails, reject_if: :all_blank, allow_destroy: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def as_json(options = {})
     defaults = { include: [:questions, :notify_emails] }
 

--- a/app/models/admin/staffing.rb
+++ b/app/models/admin/staffing.rb
@@ -29,11 +29,6 @@ class Admin::Staffing < ApplicationRecord
   after_save     :update_staffing_jobs, if: :saved_change_to_counts_towards_debt?
   before_destroy :reminder_cleanup
 
-  default_scope -> { order('start_time ASC') }
-
-  scope :future, -> { where(['end_time >= ?', DateTime.now]) }
-  scope :past, -> { where(['end_time < ?', DateTime.now]) }
-
   has_many :staffing_jobs, as: :staffable, class_name: 'Admin::StaffingJob', dependent: :destroy
   has_many :users, through: :staffing_jobs
 
@@ -43,6 +38,13 @@ class Admin::Staffing < ApplicationRecord
   accepts_nested_attributes_for :staffing_jobs, reject_if: :all_blank, allow_destroy: true
 
   acts_as_url :show_title, url_attribute: :slug, sync_url: true, allow_duplicates: true
+
+  normalizes :show_title, with: -> (value) { value&.strip }
+
+  default_scope -> { order('start_time ASC') }
+
+  scope :future, -> { where(['end_time >= ?', DateTime.now]) }
+  scope :past, -> { where(['end_time < ?', DateTime.now]) }
 
   def self.ransackable_attributes(auth_object = nil)
     %w[start_time show_title reminder_job_id end_time counts_towards_debt slug]

--- a/app/models/admin/staffing_job.rb
+++ b/app/models/admin/staffing_job.rb
@@ -27,6 +27,8 @@ class Admin::StaffingJob < ApplicationRecord
 
   has_paper_trail limit: 6
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   # The functions that use staffable don't check if it's a staffing instead of a template.
   # They should just hard-fail when the staffable is a template. That situation should simply not occur.
 

--- a/app/models/admin/staffing_template.rb
+++ b/app/models/admin/staffing_template.rb
@@ -18,6 +18,8 @@ class Admin::StaffingTemplate < ApplicationRecord
 
   accepts_nested_attributes_for :staffing_jobs, reject_if: :all_blank, allow_destroy: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def as_json(options = {})
     defaults = { include: [staffing_jobs: {}] }
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -35,6 +35,8 @@ class Attachment < ApplicationRecord
 
   has_one_attached :file
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   default_scope -> { order('name ASC') }
 
   ACCESS_LEVELS = [

--- a/app/models/attachment_tag.rb
+++ b/app/models/attachment_tag.rb
@@ -16,6 +16,8 @@ class AttachmentTag < ApplicationRecord
 
   has_and_belongs_to_many :attachments, optional: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   default_scope { order(:ordering) }
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/carousel_item.rb
+++ b/app/models/carousel_item.rb
@@ -15,12 +15,15 @@
 # == Schema Information End
 #++
 class CarouselItem < ApplicationRecord
+  CAROUSEL_NAMES = ['Home'].freeze
+
   validates :title, :tagline, :carousel_name, :ordering, presence: true
+  validates :carousel_name, inclusion: { in: CAROUSEL_NAMES }
   validates :image, attached: true
 
   has_one_attached :image
 
-  CAROUSEL_NAMES = ['Home'].freeze
+  normalizes :title, :tagline, with: -> (value) { value&.strip }
 
   def self.active_and_ordered
     return where(is_active: true).order('ordering')

--- a/app/models/complaint.rb
+++ b/app/models/complaint.rb
@@ -18,6 +18,8 @@ class Complaint < ApplicationRecord
 
   before_destroy :stop_destroy
 
+  normalizes :subject, with: -> (subject) { subject&.strip }
+
   # Everyone can create and it should not be possible to delete complaints.
   DISABLED_PERMISSIONS = %w[create destroy].freeze
 

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: emails
+#
+# *id*::                   <tt>bigint, not null, primary key</tt>
+# *email*::                <tt>string(255)</tt>
+# *attached_object_type*:: <tt>string(255), not null</tt>
+# *attached_object_id*::   <tt>bigint, not null</tt>
+# *created_at*::           <tt>datetime, not null</tt>
+# *updated_at*::           <tt>datetime, not null</tt>
+#--
+# == Schema Information End
+#++
 class Email < ApplicationRecord
   belongs_to :attached_object, polymorphic: true, optional: false
   validates :email, presence: true

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -4,4 +4,6 @@ class Email < ApplicationRecord
 
   # No duplicate emails on the same attached_object.
   validates_uniqueness_of :email, scope: [:attached_object_type, :attached_object_id]
+
+  normalizes :email, with: -> (email) { email&.downcase.strip }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -82,6 +82,9 @@ class Event < ApplicationRecord
 
   validates :image, content_type: %i[png jpg jpeg gif]
 
+  # Normalizatios
+  normalizes :name, :tagline, :slug, :author, :price, with: -> (value) { value&.strip }
+
   # Scopes #
 
   scope :current, -> { where(['end_date >= ? AND is_public = ?', Date.current, true]) }

--- a/app/models/event_tag.rb
+++ b/app/models/event_tag.rb
@@ -18,6 +18,8 @@ class EventTag < ApplicationRecord
 
   default_scope { order(:ordering) }
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[description id name ordering]
   end

--- a/app/models/fault_report.rb
+++ b/app/models/fault_report.rb
@@ -20,6 +20,8 @@ class FaultReport < ApplicationRecord
   belongs_to :reported_by,  class_name: 'User'
   belongs_to :fixed_by,     class_name: 'User', optional: true
 
+  normalizes :item, with: -> (item) { item&.strip }
+
   enum severity: {
     annoying: 0,
     probably_worth_fixing: 1,

--- a/app/models/marketing_creatives/category.rb
+++ b/app/models/marketing_creatives/category.rb
@@ -22,6 +22,8 @@ class MarketingCreatives::Category < ApplicationRecord
   has_one_attached :image
   validates :image, content_type: %i[png jpg jpeg gif]
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def to_param
     url
   end

--- a/app/models/marketing_creatives/profile.rb
+++ b/app/models/marketing_creatives/profile.rb
@@ -25,6 +25,8 @@ class MarketingCreatives::Profile < ApplicationRecord
 
   belongs_to :user, optional: true
 
+  normalizes :name, :url, with: -> (value) { value&.strip }
+
   def to_param
     url
   end

--- a/app/models/mass_mail.rb
+++ b/app/models/mass_mail.rb
@@ -22,6 +22,8 @@ class MassMail < ApplicationRecord
 
   before_destroy :check_if_mail_has_been_sent
 
+  normalizes :subject, with: -> (subject) { subject&.strip }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[body draft send_date sender_id subject]
   end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -45,6 +45,8 @@ class News < ApplicationRecord
 
   validates :image, content_type: %i[png jpg jpeg gif]
 
+  normalizes :title, :slug, with: -> (value) { value&.strip }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[body publish_date show_public slug title]
   end

--- a/app/models/newsletter_subscriber.rb
+++ b/app/models/newsletter_subscriber.rb
@@ -18,4 +18,6 @@
 #++
 class NewsletterSubscriber < ApplicationRecord
   validates :email, presence: true
+
+  normalizes :email, with: -> (email) {email&.downcase&.strip }
 end

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -21,6 +21,8 @@ class Opportunity < ApplicationRecord
 
   validates :title, :expiry_date, :description, :creator_id, presence: true
 
+  normalizes :title, with: -> (title) { title&.strip }
+
   # If you update this, you must also update the active? method and the permission somewhere at the top of ability.rb.
   # You might also have to update the opportunities helper.
   scope :active, -> { where('approved = true AND expiry_date > ?', Time.now).order('expiry_date ASC') }

--- a/app/models/picture_tag.rb
+++ b/app/models/picture_tag.rb
@@ -16,6 +16,8 @@ class PictureTag < ApplicationRecord
 
   has_and_belongs_to_many :pictures, optional: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[description name id ordering]
   end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -25,6 +25,8 @@ class Review < ApplicationRecord
 
   belongs_to :event
 
+  normalizes :reviewer, :organisation, :title, with: -> (value) { value&.strip }
+  
   def reviewer_with_organisation
     return "#{reviewer}#{" for #{organisation}" if organisation.present?}"
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -31,6 +31,8 @@ class Role < ApplicationRecord
 
   scopify
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[name]
   end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -21,14 +21,16 @@ class TeamMember < ActiveRecord::Base
   validates :position, :user, presence: true
   validates_uniqueness_of :user_id, scope: [:teamwork_type, :teamwork_id]
   
-  default_scope -> { order('position ASC') }
-
   # It should not be optional, but otherwise this fails on creation when immediately attaching team members.
   # A little bit annoying, definitely.
   belongs_to :teamwork, polymorphic: true, optional: true
   belongs_to :user
 
   delegate :name, to: :user, prefix: true
+
+  normalizes :position, with: -> (position) { position&.strip }
+
+  default_scope -> { order('position ASC') }
 
   def self.ransackable_attributes(auth_object = nil)
     %w[position user_id teamwork_id teamwork_type]

--- a/app/models/techie.rb
+++ b/app/models/techie.rb
@@ -23,6 +23,8 @@ class Techie < ApplicationRecord
 
   accepts_nested_attributes_for :children, :parents, reject_if: :all_blank, allow_destroy: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   default_scope -> { order('name ASC') }
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,9 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
+  normalizes :email, with: -> (email) { email&.downcase.strip }
+  normalizes :first_name, :last_name, :username, with: -> (name) { name&.strip }
+
   default_scope -> { order('last_name ASC') }
 
   # Also change the method 'consented'

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -37,6 +37,9 @@ class Venue < ApplicationRecord
 
   validates :image, content_type: %i[png jpg jpeg gif]
 
+  normalizes :email, with: -> (email) { email&.downcase&.strip }
+  normalizes :name, :tagline, with: -> (value) { value&.strip }
+
   default_scope -> { order('name ASC') }
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/video_link.rb
+++ b/app/models/video_link.rb
@@ -20,6 +20,8 @@ class VideoLink < ApplicationRecord
   validate :link_is_valid
   validates :name, :link, :access_level, presence: true
 
+  normalizes :name, with: -> (name) { name&.strip }
+
   default_scope -> { order(order: :asc) }
 
   # They're the same, so why not?

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :user, 'deploy'
 
 set :keep_releases, 4
 
-set :linked_files, %w(config/database.yml config/credentials.yml.enc config/master.key config/openid_signing_key)
+set :linked_files, %w(config/database.yml config/master.key config/openid_signing_key)
 set :linked_dirs, %w(log bundle tmp/pids tmp/cache tmp/sockets public/system public/assets public/packs node_modules uploads storage .duplicacy)
 
 # TODO: Run zeitwerk:check

--- a/test/factories/email_factory.rb
+++ b/test/factories/email_factory.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: emails
+#
+# *id*::                   <tt>bigint, not null, primary key</tt>
+# *email*::                <tt>string(255)</tt>
+# *attached_object_type*:: <tt>string(255), not null</tt>
+# *attached_object_id*::   <tt>bigint, not null</tt>
+# *created_at*::           <tt>datetime, not null</tt>
+# *updated_at*::           <tt>datetime, not null</tt>
+#--
+# == Schema Information End
+#++
 FactoryBot.define do
   factory :email do
     email { Faker::Internet.email }

--- a/test/fixtures/emails.yml
+++ b/test/fixtures/emails.yml
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: emails
+#
+# *id*::                   <tt>bigint, not null, primary key</tt>
+# *email*::                <tt>string(255)</tt>
+# *attached_object_type*:: <tt>string(255), not null</tt>
+# *attached_object_id*::   <tt>bigint, not null</tt>
+# *created_at*::           <tt>datetime, not null</tt>
+# *updated_at*::           <tt>datetime, not null</tt>
+#--
+# == Schema Information End
+#++
 notify_email_one:
   attached_object_id: 1
   attached_object_type: Admin::Questionnaires::QuestionnaireTemplate

--- a/test/fixtures/maintenance_attendances.yml
+++ b/test/fixtures/maintenance_attendances.yml
@@ -1,4 +1,15 @@
-
+# == Schema Information
+#
+# Table name: maintenance_attendances
+#
+# *id*::                     <tt>bigint, not null, primary key</tt>
+# *maintenance_session_id*:: <tt>bigint, not null</tt>
+# *user_id*::                <tt>integer, not null</tt>
+# *created_at*::             <tt>datetime, not null</tt>
+# *updated_at*::             <tt>datetime, not null</tt>
+#--
+# == Schema Information End
+#++
 one:
   user: iolanthe_faerie
   maintenance_session: one

--- a/test/fixtures/maintenance_sessions.yml
+++ b/test/fixtures/maintenance_sessions.yml
@@ -1,2 +1,13 @@
+# == Schema Information
+#
+# Table name: maintenance_sessions
+#
+# *id*::         <tt>bigint, not null, primary key</tt>
+# *date*::       <tt>date</tt>
+# *created_at*:: <tt>datetime, not null</tt>
+# *updated_at*:: <tt>datetime, not null</tt>
+#--
+# == Schema Information End
+#++
 one:
   date: '2023-10-09'

--- a/test/models/email_test.rb
+++ b/test/models/email_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: emails
+#
+# *id*::                   <tt>bigint, not null, primary key</tt>
+# *email*::                <tt>string(255)</tt>
+# *attached_object_type*:: <tt>string(255), not null</tt>
+# *attached_object_id*::   <tt>bigint, not null</tt>
+# *created_at*::           <tt>datetime, not null</tt>
+# *updated_at*::           <tt>datetime, not null</tt>
+#--
+# == Schema Information End
+#++
 require "test_helper"
 
 class EmailTest < ActiveSupport::TestCase

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: roles
+#
+# *id*::            <tt>integer, not null, primary key</tt>
+# *name*::          <tt>string(255)</tt>
+# *created_at*::    <tt>datetime, not null</tt>
+# *updated_at*::    <tt>datetime, not null</tt>
+# *resource_type*:: <tt>string(255)</tt>
+# *resource_id*::   <tt>bigint</tt>
+#--
+# == Schema Information End
+#++
 require 'test_helper'
 
 class RoleTest < ActionView::TestCase


### PR DESCRIPTION
# Features
- Add normalizations to models. Mainly stripping string fields from starting and trailing whitespace, and downcasing emails.

# Fixes
- Remove credentials.yml.enc from the linked_files in the deploy file because it is in the repo
- Add csv to gemfile as it will be removed from the standard library in Ruby 3.4
- Add select2.js (a helper script) to the manifest.js
- Annotate models again after some new ones were added