### PR TITLE
Remove almost all json responses

### DIFF
--- a/app/controllers/admin/debts_controller.rb
+++ b/app/controllers/admin/debts_controller.rb
@@ -15,7 +15,7 @@ class Admin::DebtsController < AdminController
     respond_to do |format|
       format.html
       # TODO: This should include the debt stats and not actually the user info. Do something with a local class.
-      format.json { render json: @users }
+      # format.json { render json: @users }
     end
   end
 
@@ -35,7 +35,7 @@ class Admin::DebtsController < AdminController
     respond_to do |format|
       format.html
       # TODO: Same as above
-      format.json { render json: @users }
+      # format.json { render json: @users }
     end
   end
 end

--- a/app/controllers/admin/feedbacks_controller.rb
+++ b/app/controllers/admin/feedbacks_controller.rb
@@ -52,10 +52,10 @@ class Admin::FeedbacksController < AdminController
             redirect_to admin_show_path(@show)
           end
         end
-        format.json { render json: @feedback, status: :created, location: @feedback }
+        # format.json { render json: @feedback, status: :created, location: @feedback }
       else
         format.html { render 'new', status: :unprocessable_entity }
-        format.json { render json: @feedback.errors, status: :unprocessable_entity }
+        # format.json { render json: @feedback.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/admin/maintenance_debts_controller.rb
+++ b/app/controllers/admin/maintenance_debts_controller.rb
@@ -37,7 +37,7 @@ class Admin::MaintenanceDebtsController < AdminController
 
     respond_to do |format|
       format.html { redirect_to admin_maintenance_debts_path }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 
@@ -47,7 +47,7 @@ class Admin::MaintenanceDebtsController < AdminController
 
     respond_to do |format|
       format.html { redirect_to admin_maintenance_debts_url, notice: 'Maintenance Debt converted to Staffing Debt' }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 

--- a/app/controllers/admin/marketing_creatives/profiles_controller.rb
+++ b/app/controllers/admin/marketing_creatives/profiles_controller.rb
@@ -18,7 +18,7 @@ class Admin::MarketingCreatives::ProfilesController < AdminController
 
     respond_to do |format|
       format.html # sign_up.html.erb
-      format.json { render json: @profile }
+      # format.json { render json: @profile }
     end
   end
 

--- a/app/controllers/admin/mass_mails_controller.rb
+++ b/app/controllers/admin/mass_mails_controller.rb
@@ -29,7 +29,7 @@ class Admin::MassMailsController < AdminController
 
       respond_to do |format|
         format.html { redirect_to admin_mass_mails_url }
-        format.json { head :no_content }
+        # format.json { head :no_content }
       end
     end
   end
@@ -75,7 +75,7 @@ class Admin::MassMailsController < AdminController
 
       respond_to do |format|
         format.html { redirect_back fallback_location: admin_mass_mails_url }
-        format.json { render json: { error: flash[:error] } }
+        # format.json { render json: { error: flash[:error] } }
       end
     end
   end

--- a/app/controllers/admin/membership_activation_tokens_controller.rb
+++ b/app/controllers/admin/membership_activation_tokens_controller.rb
@@ -113,7 +113,7 @@ class Admin::MembershipActivationTokensController < AdminController
 
     respond_to do |format|
       format.html { render 'new', status: :unprocessable_entity }
-      format.json { render json: flash[:error], status: :unprocessable_entity }
+      # format.json { render json: flash[:error], status: :unprocessable_entity }
     end
   end
 end

--- a/app/controllers/admin/opportunities_controller.rb
+++ b/app/controllers/admin/opportunities_controller.rb
@@ -62,7 +62,7 @@ class Admin::OpportunitiesController < AdminController
 
     respond_to do |format|
       format.html { redirect_to admin_opportunity_url(@opportunity) }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 
@@ -86,7 +86,7 @@ class Admin::OpportunitiesController < AdminController
 
     respond_to do |format|
       format.html { redirect_to admin_opportunity_url(@opportunity) }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 

--- a/app/controllers/admin/proposals/calls_controller.rb
+++ b/app/controllers/admin/proposals/calls_controller.rb
@@ -31,7 +31,7 @@ class Admin::Proposals::CallsController < AdminController
 
     respond_to do |format|
       format.html { redirect_to admin_proposals_calls_path }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 

--- a/app/controllers/admin/proposals/proposals_controller.rb
+++ b/app/controllers/admin/proposals/proposals_controller.rb
@@ -105,9 +105,8 @@ class Admin::Proposals::ProposalsController < AdminController
     end
 
     respond_to do |format|
-
       format.html { redirect_to admin_proposals_proposal_path(@proposal) }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 
@@ -125,9 +124,8 @@ class Admin::Proposals::ProposalsController < AdminController
     end
 
     respond_to do |format|
-
       format.html { redirect_to admin_proposals_proposal_path(@proposal) }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 
@@ -148,7 +146,7 @@ class Admin::Proposals::ProposalsController < AdminController
     ensure
       respond_to do |format|
         format.html { redirect_to admin_proposals_proposal_path(@proposal) }
-        format.json { head :no_content }
+        # format.json { head :no_content }
       end
     end
   end

--- a/app/controllers/admin/questionnaires/questionnaires_controller.rb
+++ b/app/controllers/admin/questionnaires/questionnaires_controller.rb
@@ -33,7 +33,7 @@ class Admin::Questionnaires::QuestionnairesController < AdminController
 
       respond_to do |format|
         format.html { redirect_to Admin::Questionnaires::Questionnaire }
-        format.json { render json: flash[:error] }
+        # format.json { render json: flash[:error] }
       end
     else
       super
@@ -63,7 +63,7 @@ class Admin::Questionnaires::QuestionnairesController < AdminController
 
     respond_to do |format|
       format.html # answer.html.erb
-      format.json { render json: @questionnaire }
+      # format.json { render json: @questionnaire }
     end
   end
 
@@ -85,10 +85,10 @@ class Admin::Questionnaires::QuestionnairesController < AdminController
         end
 
         format.html { redirect_to @questionnaire }
-        format.json { head :no_content }
+        # format.json { head :no_content }
       else
         format.html { render 'answer', status: :unprocessable_entity }
-        format.json { render json: @questionnaire.errors, status: :unprocessable_entity }
+        # format.json { render json: @questionnaire.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/admin/staffing_debts_controller.rb
+++ b/app/controllers/admin/staffing_debts_controller.rb
@@ -38,7 +38,7 @@ class Admin::StaffingDebtsController < AdminController
 
     respond_to do |format|
       format.html { redirect_to admin_staffing_debts_path }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 
@@ -48,7 +48,7 @@ class Admin::StaffingDebtsController < AdminController
 
     respond_to do |format|
       format.html { redirect_to admin_staffing_debts_url, notice: 'Staffing Debt converted to Maintenance Debt' }
-      format.json { head :no_content }
+      # format.json { head :no_content }
     end
   end
 

--- a/app/controllers/admin/staffings_controller.rb
+++ b/app/controllers/admin/staffings_controller.rb
@@ -31,7 +31,7 @@ class Admin::StaffingsController < AdminController
 
     respond_to do |format|
       format.html # index.html.erb
-      format.json { render json: @staffings }
+      # format.json { render json: @staffings }
     end
   end
 
@@ -69,7 +69,7 @@ class Admin::StaffingsController < AdminController
 
     respond_to do |format|
       format.html # index.html.erb
-      format.json { render json: @staffings_hash }
+      # format.json { render json: @staffings_hash }
     end
   end
 
@@ -163,11 +163,11 @@ class Admin::StaffingsController < AdminController
       if failure
         set_new_params
         format.html { render 'new', status: :unprocessable_entity }
-        format.json { render json: @staffing.errors, status: :unprocessable_entity }
+        # format.json { render json: @staffing.errors, status: :unprocessable_entity }
       else
         flash[:success] = 'Staffing was successfully created.'
         format.html { redirect_to grid_admin_staffings_path(slug) }
-        format.json { render status: :created }
+        # format.json { render status: :created }
       end
     end
   end
@@ -186,10 +186,10 @@ class Admin::StaffingsController < AdminController
       if @staffing.save
         flash[:success] = 'Staffing was successfully updated.'
         format.html { redirect_to admin_staffing_path(@staffing) }
-        format.json { head :no_content }
+        # format.json { head :no_content }
       else
         format.html { render 'edit', status: :unprocessable_entity }
-        format.json { render json: @staffing.errors, status: :unprocessable_entity }
+        # format.json { render json: @staffing.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -214,7 +214,7 @@ class Admin::StaffingsController < AdminController
         helpers.append_to_flash(:erorr, 'There was an error signing up. Please contact the Front of House Manager') if flash[:error].blank?
         
         format.html { redirect_to admin_staffing_path(@job.staffable) }
-        format.json { render json: @job.errors, status: :unprocessable_entity }
+        # format.json { render json: @job.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -242,12 +242,12 @@ class Admin::StaffingsController < AdminController
         helpers.append_to_flash(:success, "Thank you for choosing to staff #{@job.staffable.show_title} - #{@job.name} on #{(l @job.staffable.start_time, format: :short)}.")
 
         format.html { redirect_to admin_staffing_path(@job.staffable) }
-        format.json { render json: @job.to_json(include: { user: {}, staffable: {} }, methods: %I[js_start_time js_end_time]) }
+        # format.json { render json: @job.to_json(include: { user: {}, staffable: {} }, methods: %I[js_start_time js_end_time]) }
       else
         helpers.append_to_flash(:erorr, 'There was an error signing up. Please contact the Front of House Manager') if flash[:error].blank?
 
         format.html { redirect_to admin_staffing_path(@job.staffable) }
-        format.json { render json: @job.errors, status: :unprocessable_entity }
+        # format.json { render json: @job.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,6 @@ class EventsController < PublicGenericEventsController
   def find_by_xts_id
     @event = Event.find_by_xts_id(params[:id])
 
-    render json: @event.to_json(methods: [:slideshow_image_url], include: [pictures: { methods: [:display_url] }])
+    # render json: @event.to_json(methods: [:slideshow_image_url], include: [pictures: { methods: [:display_url] }])
   end
 end

--- a/app/controllers/generic_controller.rb
+++ b/app/controllers/generic_controller.rb
@@ -20,7 +20,7 @@ module GenericController
 
     respond_to do |format|
       format.html { render index_filename }
-      format.json { render json: resources }
+      # format.json { render json: resources }
     end
   end
 
@@ -29,7 +29,7 @@ module GenericController
 
     respond_to do |format|
       format.html # show.html.erb
-      format.json { render json: get_resource }
+      # format.json { render json: get_resource }
     end
   end
 
@@ -38,7 +38,7 @@ module GenericController
 
     respond_to do |format|
       format.html # new.html.erb
-      format.json { render json: get_resource }
+      # format.json { render json: get_resource }
     end
   end
 
@@ -52,10 +52,10 @@ module GenericController
         on_create_success
 
         format.html { redirect_to(create_redirect_url) }
-        format.json { render json: get_resource, status: :created }
+        # format.json { render json: get_resource, status: :created }
       else
         format.html { render 'new', status: :unprocessable_entity }
-        format.json { render json: get_resource.errors, status: :unprocessable_entity }
+        # format.json { render json: get_resource.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -65,7 +65,7 @@ module GenericController
 
     respond_to do |format|
       format.html # new.html.erb
-      format.json { render json: get_resource }
+      # format.json { render json: get_resource }
     end
   end
 
@@ -77,12 +77,12 @@ module GenericController
         on_update_success
 
         format.html { redirect_to(update_redirect_url) }
-        format.json { render json: [:admin, get_resource], status: :updated }
+        # format.json { render json: [:admin, get_resource], status: :updated }
       else
         @title = edit_title
 
         format.html { render 'edit', status: :unprocessable_entity }
-        format.json { render json: get_resource.errors, status: :unprocessable_entity }
+        # format.json { render json: get_resource.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -96,7 +96,7 @@ module GenericController
 
     respond_to do |format|
       format.html { redirect_to(url) }
-      format.json { format.json { render json: flash[:error] } }
+      # format.json { format.json { render json: flash[:error] } }
     end
   end
 

--- a/app/controllers/membership_activation_tokens_controller.rb
+++ b/app/controllers/membership_activation_tokens_controller.rb
@@ -21,7 +21,7 @@ class MembershipActivationTokensController < ApplicationController
       unless @user.save
         respond_to do |format|
           format.html { render 'activate', status: :unprocessable_entity }
-          format.json { render json: user.errors, status: :unprocessable_entity }
+          # format.json { render json: user.errors, status: :unprocessable_entity }
         end
         return
       end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -48,7 +48,7 @@ class StaticController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to(static_url('contact')) }
-      format.json { render json: success_message }
+      # format.json { render json: success_message }
     end
   end
 end


### PR DESCRIPTION
Remove almost all json responses on actions as it is too easy to accidentally leak data, and they have not been properly set up. 

Leave json responses intact for the few api endpoints, such as membership checker, markdown preview renderer, user autocomplete list. 

Also keep the one in mass mails controller as that one is needed for some tests