### PR TITLE
Fix template loading for questionnaires and staffing templates

### DIFF
--- a/app/assets/javascripts/admin/question_templates.js
+++ b/app/assets/javascripts/admin/question_templates.js
@@ -20,6 +20,7 @@ class TemplateLoader {
     this.itemsType = $('meta[name="templates-items-type"]').attr("content");
     this.templateItem = null; // Holds the current item being added from the template
     this.globalData = null;  // Stores all data for the selected template
+    this.allTemplates = []; // New property to store all templates
 
     this.validateSetup();
     this.initEventListeners();
@@ -30,6 +31,12 @@ class TemplateLoader {
     if (!this.templatesBaseUrl) {
       alert("'templates_base_url' is null. Is it set properly?");
     }
+
+    // if the templatesBaseUrl does not end in '.json', add '.json' to the end.
+    if (!this.templatesBaseUrl.endsWith('.json')) {
+      this.templatesBaseUrl += '.json';
+    }
+
     if (!this.itemsType || ![ITEMS_TYPE.QUESTIONS, ITEMS_TYPE.JOBS].includes(this.itemsType)) {
       alert("'items_type' is null or not 'questions' or 'jobs'. Is it set properly?");
     }
@@ -58,19 +65,19 @@ class TemplateLoader {
         insertedItem.find('[name$="[question_text]"]').val(this.templateItem.question_text);
         insertedItem.find('[name$="[response_type]"]').val(this.templateItem.response_type);
       } else if (insertedItem.hasClass('email')) {
-      // Populate email for notify emails
+        // Populate email for notify emails
         insertedItem.find('[name$="[email]"]').val(this.templateItem.email);
       }
     } else if (this.itemsType === ITEMS_TYPE.JOBS) {
       // Populate job name for staffing jobs
       insertedItem.find('[name$="[name]"]').val(this.templateItem.name);
     }
-    }
+  }
 
   // Trigger the loading of template items when the "Load" button is clicked
   loadTemplate() {
     if (this.itemsType === ITEMS_TYPE.QUESTIONS) {
-        // For questions, load both questions and notify emails
+      // For questions, load both questions and notify emails
       this.loadTemplateHelper('question_add_button', this.globalData.questions);
       this.loadTemplateHelper('notify_email_add_button', this.globalData.notify_emails);
     } else if (this.itemsType === ITEMS_TYPE.JOBS) {
@@ -83,7 +90,7 @@ class TemplateLoader {
   loadTemplateHelper(addFieldsButtonClass, templateItems) {
     templateItems.forEach(item => {
       this.templateItem = item;
-  // This loops over every item in the template and clicks the corresponding 'add fields' button.
+      // This loops over every item in the template and clicks the corresponding 'add fields' button.
       // This then triggers the cocoon:after-insert event (see above) which will insert the data into the fields.
       $('.' + addFieldsButtonClass).first().trigger('click');
     });
@@ -105,14 +112,20 @@ class TemplateLoader {
       return;
     }
 
-    // Fetch the template data from the server
-    $.getJSON(`${this.templatesBaseUrl}/${templateId}.json`, data => {
-      this.globalData = data;
+    // Find the selected template from the allTemplates array
+    const selectedTemplate = this.allTemplates.find(template => template.id == templateId);
+
+    if (selectedTemplate) {
+      this.globalData = selectedTemplate;
       this.updateTemplateSummary();
       // Enable the load button and bind the loadTemplate method
       $('#template_load').on('click', this.loadTemplate.bind(this));
       $('#template_load').removeClass('disabled');
-    });
+    } else {
+      console.error('Selected template not found in the loaded templates: ' + templateId);
+      $('#template_summary').empty().append('<p>Error: Template not found</p>');
+      $('#template_load').addClass('disabled');
+    }
   }
 
   // Update the template summary list in the modal
@@ -137,15 +150,15 @@ class TemplateLoader {
       .done(data => {
         if (Array.isArray(data) && data.length > 0) {
           this.allTemplates = data; // Store all templates
-      data.forEach(template => {
-        $('#template_list').append(`<option value="${template.id}">${template.name}</option>`);
-      });
+          data.forEach(template => {
+            $('#template_list').append(`<option value="${template.id}">${template.name}</option>`);
+          });
         } else {
           console.log('Data is empty or not an array');
         }
       })
       .fail((jqXHR, textStatus, errorThrown) => {
         console.error('AJAX request failed:', textStatus, errorThrown);
-    });
+      });
   }
 }

--- a/app/assets/javascripts/admin/question_templates.js
+++ b/app/assets/javascripts/admin/question_templates.js
@@ -133,10 +133,19 @@ class TemplateLoader {
 
   // Load the list of available templates into the dropdown
   loadTemplateList() {
-    $.getJSON(this.templatesBaseUrl, data => {
+    $.getJSON(this.templatesBaseUrl)
+      .done(data => {
+        if (Array.isArray(data) && data.length > 0) {
+          this.allTemplates = data; // Store all templates
       data.forEach(template => {
         $('#template_list').append(`<option value="${template.id}">${template.name}</option>`);
       });
+        } else {
+          console.log('Data is empty or not an array');
+        }
+      })
+      .fail((jqXHR, textStatus, errorThrown) => {
+        console.error('AJAX request failed:', textStatus, errorThrown);
     });
   }
 }

--- a/app/controllers/admin/questionnaires/questionnaire_templates_controller.rb
+++ b/app/controllers/admin/questionnaires/questionnaire_templates_controller.rb
@@ -29,4 +29,8 @@ class Admin::Questionnaires::QuestionnaireTemplatesController < AdminController
   def edit_title
     "Edit #{@questionnaire_template.name}"
   end
+
+  def json_enabled_for_index?
+    true
+  end
 end

--- a/app/controllers/admin/staffing_templates_controller.rb
+++ b/app/controllers/admin/staffing_templates_controller.rb
@@ -15,4 +15,8 @@ class Admin::StaffingTemplatesController < AdminController
   def permitted_params
     [:name, staffing_jobs_attributes: [:id, :_destroy, :name, :user, :user_id]]
   end
+
+  def json_enabled_for_index?
+    true
+  end
 end

--- a/app/controllers/generic_controller.rb
+++ b/app/controllers/generic_controller.rb
@@ -20,7 +20,7 @@ module GenericController
 
     respond_to do |format|
       format.html { render index_filename }
-      # format.json { render json: resources }
+      format.json { render json: resources } if json_enabled_for_index?
     end
   end
 
@@ -245,6 +245,10 @@ module GenericController
 
   def items_per_page
     30
+  end
+
+  def json_enabled_for_index?
+    false
   end
 
   ##

--- a/app/views/shared/form/_template_modal.erb
+++ b/app/views/shared/form/_template_modal.erb
@@ -1,4 +1,5 @@
 <%# locals: (header:, template_model:) %>
+<%# NOTE: This file has an associated question_templates.js file %>
 
 <!-- Modal -->
 <div class="modal fade" id="template_modal" tabindex="-1" aria-labelledby="template_modal_header" aria-hidden="true">


### PR DESCRIPTION
There was an error after the json endpoints were disabled. They are now re-enable for questionnaire_templates and staffing_templates. 

Additionally, I tidied up the logic in question_templates to use the already fetched array of templates when loading rather than loading the specific template again.