### PR TITLE
Add 'Bar Trained' role check when signing up for staffing

### DIFF
--- a/app/helpers/admin/staffings_helper.rb
+++ b/app/helpers/admin/staffings_helper.rb
@@ -19,6 +19,11 @@ module Admin::StaffingsHelper
         append_to_flash(:error, 'You are not DM Trained. If you think this is a mistake, please contact the Theatre Manager.')
         can_sign_up = false
       end
+    when 'bar', 'bar staff', 'barstaff'
+      unless user.has_role?('Bar Trained')
+        append_to_flash(:error, 'You are not Bar Trained. If you think this is a mistake, please contact the Front of House Manager.')
+        can_sign_up = false
+      end
     end
 
     unless user.phone_number.present?

--- a/app/helpers/team_member_helper.rb
+++ b/app/helpers/team_member_helper.rb
@@ -6,6 +6,8 @@ module TeamMemberHelper
 
         output_labels << { label_class: :info, text: 'DM Trained' } if team_member.user.has_role?('DM Trained') 
 
+        output_labels << { label_class: :info, text: 'Bar Trained' } if team_member.user.has_role?('Bar Trained')
+
         output_labels << { label_class: :success, text: 'First Aid Trained' } if team_member.user.has_role?('First Aid Trained')
 
         # Display the 'Not a Member' label if the show is this academic year, or it has a deadline in the future (and is likely a proposal)

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -34,6 +34,9 @@ welfare:
   id: 4
   name: "Welfare Contact"
 
+bar_trained:
+  name: "Bar Trained"
+
 dm_trained:
   name: "DM Trained"
 

--- a/test/helpers/admin/staffings_helper_test.rb
+++ b/test/helpers/admin/staffings_helper_test.rb
@@ -41,6 +41,15 @@ class Admin::StaffingsHelperTest < ActionView::TestCase
     assert_equal ['You are not on committee. If you think this is a mistake, please contact the Secretary.'], flash[:error]
   end
 
+  test 'members cannot sign up for bar slots' do
+    give_member_permission_to_sign_up_for_staffing
+
+    member = users(:member_with_phone_number)
+
+    assert_not check_if_current_user_can_sign_up(member, 'bar')
+    assert_equal ['You are not Bar Trained. If you think this is a mistake, please contact the Front of House Manager.'], flash[:error]
+  end
+
   test 'committee members can sign up for committee rep and DM slots' do
     committee = FactoryBot.create(:committee, phone_number: '123')
 

--- a/test/helpers/team_member_helper_test.rb
+++ b/test/helpers/team_member_helper_test.rb
@@ -13,6 +13,14 @@ class TeamMemberHelperTest < ActionView::TestCase
     assert_includes team_member_labels_for(@team_member, Date.current).join(';'), 'DM Trained'
   end
 
+  test 'Bar trained user should have the Bar trained label' do
+    assert_not @team_member.user.has_role?("Bar Trained")
+    assert_not_includes team_member_labels_for(@team_member, Date.current).join(';'), 'Bar Trained'
+
+    @team_member.user.add_role("Bar Trained")
+    assert_includes team_member_labels_for(@team_member, Date.current).join(';'), 'Bar Trained'
+  end
+
   test 'First Aid Trained user should have the First Aid Trained label' do
     assert_not @team_member.user.has_role?("First Aid Trained")
     assert_not_includes team_member_labels_for(@team_member, Date.current).join(';'), 'First Aid Trained'

--- a/test/helpers/team_member_helper_test.rb
+++ b/test/helpers/team_member_helper_test.rb
@@ -38,7 +38,7 @@ class TeamMemberHelperTest < ActionView::TestCase
   end
   
   test 'shows in previous academic years should not warn for non-members' do
-    @team_member.teamwork.update(start_date: 1.year.ago , end_date: 1.year.ago + 1.days)
+    @team_member.teamwork.update(start_date: 1.year.ago - 5.days, end_date: 1.year.ago - 4.days)
 
     @team_member.user.remove_role("Member")
     labels = team_member_labels_for(@team_member, nil).map { |l| l[:text] }


### PR DESCRIPTION
# Feature
- Check if member has the role 'Bar Trained' before letting them sign up for the 'Bar' or 'Bar Staff' role.
- Add badge for 'Bar Trained'

# Fixes
- Fix issue with 'shows in previous academic years should not warn for non-members' test when executed the day before a change of academic year.