### PR TITLE
Authorize the user autocomplete list 

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -43,6 +43,8 @@ class Admin::UsersController < AdminController
   end
 
   def autocomplete_list
+    authorize! :read, User
+
     page = [params[:page].to_i, 1].max # First page is always 1.
 
     per_page = 30 # Adjust the number of items per page as needed
@@ -69,8 +71,8 @@ class Admin::UsersController < AdminController
     params[:user].delete(:password) if params[:user][:password].blank?
     params[:user].delete(:password_confirmation) if params[:user][:password_confirmation].blank?
 
-    perm_params = [:email, :password, :password_confirmation, :remember_me, :first_name, :last_name, 
-            :phone_number, :card_number, :public_profile, :bio, :avatar, :username]
+    perm_params = %i[email password password_confirmation remember_me first_name last_name
+                     phone_number card_number public_profile bio avatar username]
 
     perm_params.push(role_ids: []) if current_user.has_role?(:admin)
 

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -66,7 +66,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
     get :edit, params: { id: @user }
     assert_response :success
 
-    assert_no_match "name=\"user[role_ids][]\"", response.body
+    assert_no_match 'name="user[role_ids][]"', response.body
   end
 
   test 'role checkboxes should be visible for admin users' do
@@ -76,7 +76,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
     get :edit, params: { id: @user }
     assert_response :success
 
-    assert_match "name=\"user[role_ids][]\"", response.body
+    assert_match 'name="user[role_ids][]"', response.body
   end
 
   test 'should update user' do
@@ -129,6 +129,14 @@ class Admin::UsersControllerTest < ActionController::TestCase
     post :reset_password, params: { id: @user }
 
     assert_redirected_to admin_user_url(@user)
+  end
+
+  test 'get autocomplete list does not work when not signed in' do
+    sign_out users(:admin)
+
+    get :autocomplete_list
+
+    assert_redirected_to new_user_session_path
   end
 
   test 'get autocomplete list' do


### PR DESCRIPTION
so that only users who are signed in can load it.

Should not break anything, but might